### PR TITLE
Convert ViewModels from ObservableObject to @Observable

### DIFF
--- a/Sources/SwiftDex/View/Bullets/Bullets.swift
+++ b/Sources/SwiftDex/View/Bullets/Bullets.swift
@@ -6,7 +6,7 @@ import SwiftUI
 public struct Bullets: View {
     let style: BulletStyle
     @EnvironmentObject var eventDispatcher: EventDispatcher
-    @StateObject var viewModel: BulletsViewModel
+    @State var viewModel: BulletsViewModel
     @ActionContext(ApplyByItem.self) var actionContext
 
     /// Creates an instance.
@@ -20,7 +20,7 @@ public struct Bullets: View {
     ) {
         self.style = style
         let viewModel = BulletsViewModel(items: items())
-        _viewModel = StateObject(wrappedValue: viewModel)
+        _viewModel = State(wrappedValue: viewModel)
     }
 
     /// The content and behavior of the view.
@@ -29,6 +29,7 @@ public struct Bullets: View {
             style: style,
             items: viewModel.items
         )
+        .environment(viewModel)
         .onReceive(eventDispatcher.forward) { _ in
             if isDynamic {
                 withAnimation(animation) {
@@ -59,7 +60,6 @@ public struct Bullets: View {
                 break
             }
         }
-        .environmentObject(viewModel)
         .animation(animation, value: actionContext.state)
         .animation(animation, value: viewModel.step)
     }
@@ -94,7 +94,7 @@ private extension Bullets {
 private struct BulletsChildView: View {
     let style: BulletStyle
     let items: [BulletItem]
-    @EnvironmentObject var viewModel: BulletsViewModel
+    @Environment(BulletsViewModel.self) var viewModel
     @ActionContext(ApplyByItem.self) var actionContext
 
     @ViewBuilder

--- a/Sources/SwiftDex/View/Bullets/BulletsViewModel.swift
+++ b/Sources/SwiftDex/View/Bullets/BulletsViewModel.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SwiftUI
 
-class BulletsViewModel: ObservableObject {
+@Observable
+class BulletsViewModel {
     let items: [BulletItem]
     let numberOfItems: Int
-    @Published
     private(set) var step = 0
 
     init(items: [BulletItem]) {

--- a/Sources/SwiftDex/View/Flipper/Flipper.swift
+++ b/Sources/SwiftDex/View/Flipper/Flipper.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// Used in combination with the `FlipByItem` Action, it allows displaying multiple views provided as `content` in a "flip" manner.
 public struct Flipper: View {
     @EnvironmentObject var eventDispatcher: EventDispatcher
-    @StateObject var viewModel: FlipperViewModel
+    @State var viewModel: FlipperViewModel
     @ActionContext(FlipByItem.self) var actionContext
 
     private let numberOfItems: Int
@@ -30,7 +30,7 @@ public struct Flipper: View {
         self.animation = animation
 
         let viewModel = FlipperViewModel(numberOfItems: numberOfItems)
-        _viewModel = StateObject(wrappedValue: viewModel)
+        _viewModel = State(wrappedValue: viewModel)
     }
 
     /// The content and behavior of the view.

--- a/Sources/SwiftDex/View/Flipper/FlipperViewModel.swift
+++ b/Sources/SwiftDex/View/Flipper/FlipperViewModel.swift
@@ -1,9 +1,9 @@
 import Foundation
 import SwiftUI
 
-class FlipperViewModel: ObservableObject {
+@Observable
+class FlipperViewModel {
     let numberOfItems: Int
-    @Published
     private(set) var step = 0
 
     init(numberOfItems: Int) {


### PR DESCRIPTION
## Summary
- Convert `FlipperViewModel` and `BulletsViewModel` from `ObservableObject` to `@Observable`
- Update views to use `@State` instead of `@StateObject` for owning Observable objects
- Update `BulletsChildView` to use `@Environment` instead of `@EnvironmentObject`
- Remove `@Published` wrapper - properties are automatically observed with `@Observable`

## Benefits
- 🚀 **Modern SwiftUI**: Uses iOS 17+ `@Observable` pattern
- 🧹 **Less boilerplate**: No more `@Published` or `ObservableObject` conformance
- ⚡ **Better performance**: More efficient observation system
- 🎯 **Cleaner code**: Direct property access without wrapper overhead

## Changes Made
- `FlipperViewModel`: `ObservableObject` → `@Observable`, `@Published var step` → `var step`
- `BulletsViewModel`: `ObservableObject` → `@Observable`, `@Published var step` → `var step`
- `Flipper` view: `@StateObject` → `@State`, `StateObject()` → `State()`
- `Bullets` view: `@StateObject` → `@State`, `StateObject()` → `State()`
- `BulletsChildView`: `@EnvironmentObject` → `@Environment`, added `.environment()` injection

## Test Plan
- [x] Build succeeds with no compilation errors
- [x] All 19 existing tests pass 
- [x] ViewModels maintain same functionality and API
- [x] Views correctly observe state changes

🤖 Generated with [Claude Code](https://claude.ai/code)