### PR TITLE
Rename ActionState isDynamic property to isActivated

### DIFF
--- a/Sources/SwiftDex/Core/Action/ActionContext.swift
+++ b/Sources/SwiftDex/Core/Action/ActionContext.swift
@@ -113,8 +113,8 @@ public extension ActionState {
         }
     }
 
-    /// Indicates whether the action state is dynamic (i.e., whether it is in the activated state).
-    var isDynamic: Bool {
+    /// Indicates whether the action state is activated (i.e., whether it is in the activated state).
+    var isActivated: Bool {
         if case .activated(_) = self {
             return true
         }

--- a/Sources/SwiftDex/View/Bullets/Bullets.swift
+++ b/Sources/SwiftDex/View/Bullets/Bullets.swift
@@ -31,14 +31,14 @@ public struct Bullets: View {
         )
         .environment(viewModel)
         .onReceive(eventDispatcher.forward) { _ in
-            if isDynamic {
+            if isActivated {
                 withAnimation(animation) {
                     viewModel.forward()
                 }
             }
         }
         .onChange(of: viewModel.step) { _, step in
-            if isDynamic, viewModel.isReachedEnd, let actionID = actionContext.state?.actionID {
+            if isActivated, viewModel.isReachedEnd, let actionID = actionContext.state?.actionID {
                 actionContext.deactivate(actionID: actionID)
             }
         }
@@ -66,8 +66,8 @@ public struct Bullets: View {
 }
 
 private extension Bullets {
-    var isDynamic: Bool {
-        actionContext.state?.isDynamic ?? false
+    var isActivated: Bool {
+        actionContext.state?.isActivated ?? false
     }
 
     var animation: Animation? {

--- a/Sources/SwiftDex/View/Flipper/Flipper.swift
+++ b/Sources/SwiftDex/View/Flipper/Flipper.swift
@@ -39,14 +39,14 @@ public struct Flipper: View {
             .id(viewModel.step)
             .transition(transition)
             .onReceive(eventDispatcher.forward) { _ in
-                if isDynamic {
+                if isActivated {
                     withAnimation(animation) {
                         viewModel.forward()
                     }
                 }
             }
             .onChange(of: viewModel.step) { _, step in
-                if isDynamic, viewModel.isReachedEnd, let actionID = actionContext.state?.actionID {
+                if isActivated, viewModel.isReachedEnd, let actionID = actionContext.state?.actionID {
                     actionContext.deactivate(actionID: actionID)
                 }
             }
@@ -77,8 +77,8 @@ public struct Flipper: View {
 }
 
 private extension Flipper {
-    var isDynamic: Bool {
-        actionContext.state?.isDynamic ?? false
+    var isActivated: Bool {
+        actionContext.state?.isActivated ?? false
     }
 
     var isAfterAction: Bool {


### PR DESCRIPTION
## Summary
Rename the `isDynamic` property in `ActionState` to `isActivated` for better clarity and accuracy.

## Changes Made
- **ActionContext.swift**: Rename `ActionState.isDynamic` → `ActionState.isActivated`
- **Flipper.swift**: Update all 3 references to use `isActivated`
- **Bullets.swift**: Update all 3 references to use `isActivated`
- Update documentation comment to reflect the new property name

## Why This Change?
The property `isDynamic` was misleading because:
- ❌ **Unclear naming**: "Dynamic" doesn't clearly indicate what state it represents
- ❌ **Imprecise**: The property specifically checks if ActionState is in `.activated` case, not just "dynamic"

The new name `isActivated` is:
- ✅ **More descriptive**: Clearly indicates it checks for `.activated` state
- ✅ **Self-documenting**: The purpose is obvious from the name
- ✅ **Accurate**: Directly corresponds to the `.activated` enum case

## Test Plan
- [x] Build succeeds with no compilation errors
- [x] All references updated consistently across the codebase
- [x] No breaking changes to public API behavior
- [x] Property logic remains identical, only name changed

## Files Changed
- `Sources/SwiftDex/Core/Action/ActionContext.swift` (2 changes)
- `Sources/SwiftDex/View/Bullets/Bullets.swift` (4 changes)  
- `Sources/SwiftDex/View/Flipper/Flipper.swift` (4 changes)

🤖 Generated with [Claude Code](https://claude.ai/code)