### PR TITLE
Fix Flipper transitions never animating

### DIFF
--- a/Sources/SwiftDex/Core/Action/ActionStepper.swift
+++ b/Sources/SwiftDex/Core/Action/ActionStepper.swift
@@ -44,7 +44,12 @@ public struct ActionStepper<A: Action, Content: View>: View {
         content(progress)
             .onReceive(eventDispatcher.forward) { _ in
                 if isActive {
-                    step += 1
+                    // `withAnimation` is required for insertion/removal transitions
+                    // (e.g. Flipper's `.id` swap); the `.animation(_:value:)` modifier
+                    // below only reliably animates value changes, not structural ones.
+                    withAnimation(resolvedAnimation) {
+                        step += 1
+                    }
                 }
             }
             .onChange(of: step) { _, step in


### PR DESCRIPTION
## Summary

Flipper's `.transition` (e.g. `.opacity`) never animated — flips always switched instantly. This predates the ActionStepper refactor: the sub-step was advanced outside any animated transaction, relying solely on the `.animation(_:value:)` modifier, which animates value changes but not reliably view insertion/removal. Wrapping the sub-step increment in `withAnimation(resolvedAnimation)` gives the `.id` swap an animated transaction, so transitions fire.

The animation is still resolved through the existing `canBeAnimated` guard, so static previews and backward navigation remain unanimated.

## Test plan

- `swift test` — 19 tests pass
- Example app: AboutFlipper now crossfades between cat images on every flip; AboutBullets and MultipleApplyByItem verified for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)