### PR TITLE
Rewrite ZoomView and HighlightView on ActionStepper

### DIFF
--- a/Sources/SwiftDex/Core/Action/ActionProgress.swift
+++ b/Sources/SwiftDex/Core/Action/ActionProgress.swift
@@ -34,6 +34,21 @@ public extension ActionProgress {
             current
         }
     }
+
+    /// The action that currently defines the element's appearance: the running or
+    /// completed action, or the most recently completed one when idle.
+    var nearestAction: A? {
+        switch self {
+        case .idle(let previous, _):
+            previous
+
+        case .active(let current, _):
+            current
+
+        case .completed(let current):
+            current
+        }
+    }
 }
 
 public extension ActionProgress where A: TransitionAction {

--- a/Sources/SwiftDex/Core/Slide/ElementAnchors.swift
+++ b/Sources/SwiftDex/Core/Slide/ElementAnchors.swift
@@ -12,7 +12,7 @@ struct ElementAnchorsPreference: PreferenceKey {
 }
 
 class ElementAnchors: ObservableObject {
-    private(set) var value: [ElementID: Anchor<CGRect>] = [:]
+    @Published private(set) var value: [ElementID: Anchor<CGRect>] = [:]
 
     func update(value: [ElementID: Anchor<CGRect>]) {
         self.value = value

--- a/Sources/SwiftDex/Core/Slide/HighlightView/HighlightView.swift
+++ b/Sources/SwiftDex/Core/Slide/HighlightView/HighlightView.swift
@@ -44,21 +44,11 @@ private extension HighlightView {
     }
 
     func targetRect(for progress: ActionProgress<Highlight>, proxy: GeometryProxy) -> CGRect? {
-        // Resolved from the previous action while idle so the cutout keeps its
-        // position during the fade-out.
-        let highlight: Highlight? =
-            switch progress {
-            case .idle(let previous, _):
-                previous
-
-            case .active(let current, _):
-                current
-
-            case .completed(let current):
-                current
-            }
-
-        guard let target = highlight?.target, let anchor = elementAnchors.value[target] else {
+        // Resolved via `nearestAction` so the cutout keeps its position during
+        // the fade-out after the action has passed.
+        guard let target = progress.nearestAction?.target,
+            let anchor = elementAnchors.value[target]
+        else {
             return nil
         }
         return proxy[anchor]

--- a/Sources/SwiftDex/Core/Slide/HighlightView/HighlightView.swift
+++ b/Sources/SwiftDex/Core/Slide/HighlightView/HighlightView.swift
@@ -2,73 +2,66 @@ import SwiftUI
 
 struct HighlightView: View {
     @EnvironmentObject private var elementAnchors: ElementAnchors
-    @State private var targetRect: CGRect?
-    @ActionContext(Highlight.self) private var actionContext
 
-    @ViewBuilder
     var body: some View {
         GeometryReader { proxy in
-            Group {
-                if let targetRect, let color = actionContext.state?.color {
-                    ZStack {
-                        Color(color)
-                        RoundedRectangle(cornerRadius: 20)
-                            .frame(width: targetRect.width + 40, height: targetRect.height + 40)
-                            .position(x: targetRect.midX, y: targetRect.midY)
-                            .blur(radius: 10)
-                            .blendMode(.destinationOut)
-                    }
-                    .compositingGroup()
-                }
-                else {
-                    EmptyView()
-                }
-            }
-            .onChange(of: actionContext.state) { _, state in
-                withAnimation(animation) {
-                    targetRect = getTargetRect(
-                        proxy: proxy
-                    )
-                }
-                switch state {
-                case .activated(let value):
-                    actionContext.deactivate(actionID: value.actionID)
-
-                default:
-                    break
-                }
+            ActionStepper(Highlight.self, count: 1) { progress in
+                overlayView(for: progress, proxy: proxy)
+            } animation: { _ in
+                .linear
             }
         }
     }
 }
 
 private extension HighlightView {
-    func getTargetRect(proxy: GeometryProxy) -> CGRect? {
-        guard let actionState = actionContext.state else {
+    // The overlay is always in the hierarchy and driven by opacity, so both its
+    // appearance and disappearance animate reliably.
+    func overlayView(for progress: ActionProgress<Highlight>, proxy: GeometryProxy) -> some View {
+        let color = progress.current?.mode.color
+        let targetRect = targetRect(for: progress, proxy: proxy)
+
+        return ZStack {
+            Color(color ?? .black)
+            RoundedRectangle(cornerRadius: 20)
+                .frame(
+                    width: (targetRect?.width ?? 0) + 40,
+                    height: (targetRect?.height ?? 0) + 40
+                )
+                .position(
+                    x: targetRect?.midX ?? 0,
+                    y: targetRect?.midY ?? 0
+                )
+                // The cutout must snap to its target; only the fade (the opacity
+                // below) is meant to animate.
+                .transaction { $0.animation = nil }
+                .blur(radius: 10)
+                .blendMode(.destinationOut)
+        }
+        .compositingGroup()
+        .opacity(color != nil && targetRect != nil ? 1 : 0)
+        .allowsHitTesting(false)
+    }
+
+    func targetRect(for progress: ActionProgress<Highlight>, proxy: GeometryProxy) -> CGRect? {
+        // Resolved from the previous action while idle so the cutout keeps its
+        // position during the fade-out.
+        let highlight: Highlight? =
+            switch progress {
+            case .idle(let previous, _):
+                previous
+
+            case .active(let current, _):
+                current
+
+            case .completed(let current):
+                current
+            }
+
+        guard let target = highlight?.target, let anchor = elementAnchors.value[target] else {
             return nil
         }
-
-        let target = actionState.target ?? .none
-        if let anchor = elementAnchors.value[target] {
-            return proxy[anchor]
-        }
-        else {
-            return nil
-        }
-    }
-
-    var animation: Animation? {
-        actionContext.canBeAnimated ? .linear : nil
-    }
-}
-
-private extension ActionState<Highlight> {
-    var color: NSColor? {
-        current?.mode.color
-    }
-
-    var target: ElementID? {
-        current?.target
+        return proxy[anchor]
     }
 }
 

--- a/Sources/SwiftDex/Core/Slide/ZoomView/ZoomView.swift
+++ b/Sources/SwiftDex/Core/Slide/ZoomView/ZoomView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 
 struct ZoomView<Content: View>: View {
     @EnvironmentObject private var elementAnchors: ElementAnchors
-    @State private var targetRect: CGRect?
-    @ActionContext(Zoom.self) private var actionContext
 
     private let content: () -> Content
 
@@ -11,73 +9,65 @@ struct ZoomView<Content: View>: View {
         self.content = content
     }
 
-    @ViewBuilder
     var body: some View {
         GeometryReader { proxy in
-            content()
-                .onChange(of: actionContext.state) { _, state in
-                    let animation: Animation?
-                    let actionID: ActionID?
-                    switch state {
-                    case .activated(let value):
-                        animation = .spring()
-                        actionID = value.actionID
-
-                    default:
-                        animation = nil
-                        actionID = nil
-                    }
-
-                    withAnimation(animation) {
-                        targetRect = getTargetRect(
-                            proxy: proxy
-                        )
-                    }
-
-                    if let actionID {
-                        actionContext.deactivate(actionID: actionID)
-                    }
+            ActionStepper(Zoom.self, count: 1) { progress in
+                ZStack(alignment: .topLeading) {
+                    content()
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .modifier(
+                    // `ignoredByLayout` keeps the zoom transform out of layout, so
+                    // anchors keep resolving in untransformed slide coordinates and a
+                    // later zoom target is not distorted by the current zoom.
+                    ZoomEffect(
+                        baseRect: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+                        targetRect: targetRect(for: progress, proxy: proxy)
+                    )
+                    .ignoredByLayout()
+                )
+            } animation: { progress in
+                progress.current != nil ? .spring() : nil
+            }
         }
-        .modifier(
-            ZoomEffect(
-                baseRect: CGRect(x: 0, y: 0, width: 1920, height: 1080),
-                targetRect: targetRect
-            )
-        )
         .clipped()
     }
 }
 
 private extension ZoomView {
-    func getTargetRect(proxy: GeometryProxy) -> CGRect? {
-        guard let actionState = actionContext.state else {
+    func targetRect(for progress: ActionProgress<Zoom>, proxy: GeometryProxy) -> CGRect? {
+        guard let zoom = progress.nearestAction else {
             return nil
         }
-        let elementID = actionState.elementID ?? .none
-        let ratio = actionState.ratio ?? 1.0
 
         let rect: CGRect
-        if let anchor = elementAnchors.value[elementID] {
+        if let anchor = elementAnchors.value[zoom.operation.elementID] {
             rect = proxy[anchor]
         }
         else {
             rect = CGRect(x: 0, y: 0, width: 1920, height: 1080)
         }
 
-        let xInset = (rect.width / ratio - rect.width) / 2
-        let yInset = (rect.height / ratio - rect.height) / 2
+        let xInset = (rect.width / zoom.ratio - rect.width) / 2
+        let yInset = (rect.height / zoom.ratio - rect.height) / 2
 
         return rect.insetBy(dx: -xInset, dy: -yInset)
     }
 }
 
-private extension ActionState<Zoom> {
-    var elementID: ElementID? {
-        (current ?? previous)?.operation.elementID
-    }
+private extension ActionProgress {
+    /// The action that currently defines the element's appearance: the running or
+    /// completed action, or the most recently completed one when idle.
+    var nearestAction: A? {
+        switch self {
+        case .idle(let previous, _):
+            previous
 
-    var ratio: CGFloat? {
-        (current ?? previous)?.ratio
+        case .active(let current, _):
+            current
+
+        case .completed(let current):
+            current
+        }
     }
 }

--- a/Sources/SwiftDex/Core/Slide/ZoomView/ZoomView.swift
+++ b/Sources/SwiftDex/Core/Slide/ZoomView/ZoomView.swift
@@ -54,20 +54,3 @@ private extension ZoomView {
         return rect.insetBy(dx: -xInset, dy: -yInset)
     }
 }
-
-private extension ActionProgress {
-    /// The action that currently defines the element's appearance: the running or
-    /// completed action, or the most recently completed one when idle.
-    var nearestAction: A? {
-        switch self {
-        case .idle(let previous, _):
-            previous
-
-        case .active(let current, _):
-            current
-
-        case .completed(let current):
-            current
-        }
-    }
-}


### PR DESCRIPTION
## Summary

ZoomView and HighlightView were the last action views with bespoke lifecycle handling: an imperative `@State` target rect updated in `onChange`, manual `withAnimation`, and hand-rolled deactivation. They are now thin render functions over `ActionStepper(_, count: 1)`, deriving the target rect purely from `ActionProgress` + element anchors.

Fixes that surfaced during the rewrite:

- **`ZoomEffect` is now `ignoredByLayout()`** — with the effect inside the `GeometryReader`, anchors resolved through the active zoom transform, so any zoom after the first targeted garbage coordinates. Keeping the transform render-only makes anchors resolve in untransformed slide coordinates.
- **Highlight cutout geometry no longer animates** — only the fade does. The rect snaps via a nil-animation transaction.
- **`ElementAnchors.value` is `@Published`** — previously anchor updates never invalidated views. Returning to a slide backward left the highlight invisible until the next state change, and derived rects could go stale after layout changes.

Behavior improvements:

- Highlight fades out on dismissal (it used to vanish instantly).
- Zoom/highlight states restore correctly when re-entering a slide.

## Test plan

- `swift test` — 19 tests pass
- Example app verified manually: AboutZoom (three consecutive zoom targets + zoom out, backward navigation, cross-slide restore) and AboutHighlight (fade-in/out with fixed cutout, restore when returning from the next slide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)