### PR TITLE
Add shader-based dissolve effect to ElementModifier

### DIFF
--- a/Examples/SwiftDexExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftDexExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		32EB5D9C7CA555D972C8AA19 /* AboutStandardLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B727C7891235FBB7D368C4A9 /* AboutStandardLayout.swift */; };
 		41EDA80C0FB3207CFE8ED445 /* Introduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F497EC9F50CC1B8B8B813C /* Introduction.swift */; };
 		5E3C4AA34F26864C37D057F6 /* AboutApply.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93EE49FF7DB4060675933EB /* AboutApply.swift */; };
+		6DAC5E01973E1F8E896894D8 /* AboutDissolve.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C63A66F76B9F61A2B37970 /* AboutDissolve.swift */; };
 		74A3546B6459532D9FC788BB /* SwiftDex in Frameworks */ = {isa = PBXBuildFile; productRef = 901786E0D97D642D5C0CE960 /* SwiftDex */; };
 		7B8070A3DC8BFF06CF1A9C70 /* AboutZoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6189BF1512A381102BFFF88 /* AboutZoom.swift */; };
 		7C59F47B5CE1149B8F6AC137 /* AboutHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475CCF49FCB2BA35E7BCCDE9 /* AboutHighlight.swift */; };
@@ -46,6 +47,7 @@
 		87F497EC9F50CC1B8B8B813C /* Introduction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Introduction.swift; sourceTree = "<group>"; };
 		AAC5BDDB4254D1D61F5EAEE8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B1F9F0DDDBC33B4282CCF9D7 /* Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Title.swift; sourceTree = "<group>"; };
+		B4C63A66F76B9F61A2B37970 /* AboutDissolve.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutDissolve.swift; sourceTree = "<group>"; };
 		B6189BF1512A381102BFFF88 /* AboutZoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutZoom.swift; sourceTree = "<group>"; };
 		B727C7891235FBB7D368C4A9 /* AboutStandardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutStandardLayout.swift; sourceTree = "<group>"; };
 		C0A17BC3CB6C02ADB509A76B /* Layout2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Layout2.swift; sourceTree = "<group>"; };
@@ -84,6 +86,7 @@
 			children = (
 				F33E50F3C38B6DA824A966BB /* AboutAction.swift */,
 				C93EE49FF7DB4060675933EB /* AboutApply.swift */,
+				B4C63A66F76B9F61A2B37970 /* AboutDissolve.swift */,
 				475CCF49FCB2BA35E7BCCDE9 /* AboutHighlight.swift */,
 				66442CB29C6A6B619C5D500B /* AboutMatchedTransition.swift */,
 				C2C23E7D5C1B84F8C87E8CC6 /* AboutTransition.swift */,
@@ -259,6 +262,7 @@
 				5E3C4AA34F26864C37D057F6 /* AboutApply.swift in Sources */,
 				FF553C08AE1066CD81EEC06A /* AboutBullets.swift in Sources */,
 				1BFBA7EA6EB6F6A3B5274EA5 /* AboutCode.swift in Sources */,
+				6DAC5E01973E1F8E896894D8 /* AboutDissolve.swift in Sources */,
 				FA85639F5460A873A20083FC /* AboutFlipper.swift in Sources */,
 				7C59F47B5CE1149B8F6AC137 /* AboutHighlight.swift in Sources */,
 				1E24A3EAE77A431FCD1CB195 /* AboutMatchedTransition.swift in Sources */,

--- a/Examples/SwiftDexExample/MyDeck.swift
+++ b/Examples/SwiftDexExample/MyDeck.swift
@@ -22,6 +22,7 @@ private extension MyDeck {
             .next(AboutMatchedTransition0(), transition: .customPush())
             .next(AboutMatchedTransition1(), transition: .matched())
             .next(AboutHighlight(), transition: .customPush())
+            .next(AboutDissolve(), transition: .customPush())
     }
 
     var customViewsFlow: some Flow {

--- a/Examples/SwiftDexExample/Slides/CustomAnimation/AboutDissolve.swift
+++ b/Examples/SwiftDexExample/Slides/CustomAnimation/AboutDissolve.swift
@@ -1,0 +1,53 @@
+import SwiftDex
+import SwiftUI
+
+struct AboutDissolve: StandardLayoutSlide {
+    @ViewBuilder
+    var head: some View {
+        "Shader Effects"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 48) {
+            "Elements can dissolve in with a **Metal shader**, driven by the Action system."
+            HStack(spacing: 80) {
+                Image("munchkin")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .cornerRadius(16)
+                    .elementID(.element(0))
+                VStack(alignment: .leading, spacing: 32) {
+                    "The grain size is configurable,"
+                        .elementID(.element(1))
+                    "from a fine sand-like dissolve"
+                        .elementID(.element(2))
+                    "to chunky pixel blocks."
+                        .elementID(.element(3))
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    @ActionContainerBuilder
+    var actionContainer: ActionContainer {
+        Apply(.dissolveIn(cellSize: 12), to: .element(0))
+        Apply(.dissolveIn(cellSize: 2), to: .element(1))
+            & Apply(.dissolveIn(cellSize: 8), to: .element(2))
+            & Apply(.dissolveIn(cellSize: 24), to: .element(3))
+    }
+}
+
+private extension ElementTransition {
+    static func dissolveIn(cellSize: CGFloat) -> ElementTransition {
+        ElementTransition(
+            animation: .easeInOut(duration: 1.4),
+            before: .dissolve(0, cellSize: cellSize)
+        )
+    }
+}
+
+#Preview {
+    SlidePreview(slide: AboutDissolve())
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "SwiftDex"
+            name: "SwiftDex",
+            resources: [.process("Shader/Dissolve.metal")]
         ),
         .testTarget(
             name: "SwiftDexTests",

--- a/Sources/SwiftDex/Core/Element/ElementModifier.swift
+++ b/Sources/SwiftDex/Core/Element/ElementModifier.swift
@@ -46,6 +46,12 @@ public struct ElementModifier {
         static let identity = Shadow(color: .clear, radius: 0, x: 0, y: 0)
     }
 
+    struct Dissolve: Equatable {
+        let progress: Double
+        let cellSize: CGFloat
+        static let identity = Dissolve(progress: 1, cellSize: 8)
+    }
+
     var isHidden: Bool = false
     var scaleEffect: ScaleEffect = .identity
     var rotationEffect: RotationEffect = .identity
@@ -53,6 +59,7 @@ public struct ElementModifier {
     var opacity: Double = 1
     var blur: Blur = .identity
     var shadow: Shadow = .identity
+    var dissolve: Dissolve = .identity
 }
 
 public extension ElementModifier {
@@ -237,6 +244,36 @@ public extension ElementModifier {
     ) -> ElementModifier {
         var `self` = self
         self.shadow = Shadow(color: color, radius: radius, x: x, y: y)
+        return self
+    }
+
+    /// Returns an `ElementModifier` that applies a shader-based dissolve effect.
+    ///
+    /// - Parameters:
+    ///   - progress: The dissolve progress; `0` is fully dissolved (invisible)
+    ///     and `1` is fully visible.
+    ///   - cellSize: The size of the dissolve grain, in points.
+    /// - Returns: An `ElementModifier` with the dissolve effect applied.
+    static func dissolve(
+        _ progress: Double,
+        cellSize: CGFloat = 8
+    ) -> ElementModifier {
+        .identity.dissolve(progress, cellSize: cellSize)
+    }
+
+    /// Add a shader-based dissolve effect to the `ElementModifier`.
+    ///
+    /// - Parameters:
+    ///   - progress: The dissolve progress; `0` is fully dissolved (invisible)
+    ///     and `1` is fully visible.
+    ///   - cellSize: The size of the dissolve grain, in points.
+    /// - Returns: An `ElementModifier` with the dissolve effect applied.
+    func dissolve(
+        _ progress: Double,
+        cellSize: CGFloat = 8
+    ) -> ElementModifier {
+        var `self` = self
+        self.dissolve = Dissolve(progress: progress, cellSize: cellSize)
         return self
     }
 }

--- a/Sources/SwiftDex/Core/Element/ElementViewModifier.swift
+++ b/Sources/SwiftDex/Core/Element/ElementViewModifier.swift
@@ -6,6 +6,12 @@ struct ElementViewModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .modifier(
+                DissolveEffect(
+                    progress: elementModifier.dissolve.progress,
+                    cellSize: elementModifier.dissolve.cellSize
+                )
+            )
             .rotationEffect(
                 elementModifier.rotationEffect.angle,
                 anchor: elementModifier.rotationEffect.anchor

--- a/Sources/SwiftDex/Shader/Dissolve.metal
+++ b/Sources/SwiftDex/Shader/Dissolve.metal
@@ -1,0 +1,23 @@
+#include <metal_stdlib>
+#include <SwiftUI/SwiftUI_Metal.h>
+using namespace metal;
+
+static float random(float2 p) {
+    return fract(sin(dot(p, float2(127.1, 311.7))) * 43758.5453123);
+}
+
+/// Dissolves a layer in or out using cell-based value noise.
+///
+/// - progress: 0 = fully dissolved (invisible), 1 = fully visible.
+/// - cellSize: The size of the dissolve grain, in points.
+[[ stitchable ]] half4 dissolve(float2 position, SwiftUI::Layer layer, float progress, float cellSize) {
+    half4 color = layer.sample(position);
+    float noise = random(floor(position / max(cellSize, 1.0)));
+
+    // Slightly overshoot the threshold so every cell (noise in [0, 1)) is
+    // fully visible at progress == 1, with a soft edge while animating.
+    float threshold = progress * 1.05;
+    float visibility = smoothstep(noise, noise + 0.05, threshold);
+
+    return color * half(visibility);
+}

--- a/Sources/SwiftDex/Shader/DissolveEffect.swift
+++ b/Sources/SwiftDex/Shader/DissolveEffect.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Applies the dissolve shader to a view with an animatable progress.
+///
+/// `Shader` arguments are not animatable by themselves, so this modifier
+/// conforms to `Animatable` and re-renders the shader for every interpolated
+/// progress value.
+struct DissolveEffect: ViewModifier, Animatable {
+    var progress: Double
+    var cellSize: Double
+
+    var animatableData: Double {
+        get { progress }
+        set { progress = newValue }
+    }
+
+    func body(content: Content) -> some View {
+        content.layerEffect(
+            ShaderLibrary.bundle(.module).dissolve(
+                .float(progress),
+                .float(cellSize)
+            ),
+            maxSampleOffset: .zero,
+            isEnabled: progress < 1
+        )
+    }
+}


### PR DESCRIPTION
## Summary

First Metal shader integration, following the direction of enabling presentations that slide-tool-class software can't do.

- **`Dissolve.metal`** — a `layerEffect` shader that dissolves a layer in/out using cell-based value noise, with configurable grain size (`cellSize`). Compiled by SwiftPM via `resources: [.process(...)]`; no new dependencies.
- **`DissolveEffect`** — shader uniforms are not animatable by themselves, so this `ViewModifier` conforms to `Animatable` and feeds the interpolated progress into the shader every frame. This is the plumbing pattern to reuse for future shader effects.
- **`ElementModifier.dissolve(_:cellSize:)`** — slots into the existing declarative API as a modifier phase, so it composes with `Apply`/`ApplyByItem` exactly like `opacity` or `blur`:
  ```swift
  ElementTransition(
      animation: .easeInOut(duration: 1.4),
      before: .dissolve(0, cellSize: 12)
  )
  ```
- **`AboutDissolve` example slide** — an image and three text lines dissolving in with different grain sizes (fine sand → chunky pixel blocks).

## Notes for review

- The shader overshoots the threshold slightly (`progress * 1.05`) so every noise cell is fully visible at `progress == 1`, with a soft `smoothstep` edge while animating.
- `layerEffect(isEnabled: progress < 1)` keeps the shader a no-op passthrough for the (common) fully-visible state.
- The Xcode project diff is from `make proj` picking up the new example slide.

## Test plan

- `swift test` — 31 tests pass; library and example app build clean
- Verified visually in the example app: dissolve-in animation, per-element grain sizes, backward navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)