### PR TITLE
Add slideSize to DeckStyle and pass it via Environment

### DIFF
--- a/Sources/SwiftDex/Core/Deck/DeckController.swift
+++ b/Sources/SwiftDex/Core/Deck/DeckController.swift
@@ -38,15 +38,17 @@ public final class DeckController {
         self.slideNumber = min(max(0, slideNumber), flow.count - 1)
         state = SlideState(actionContainer: flow[self.slideNumber].0.actionContainer)
 
+        let size = T.deckStyle.slideSize
         for (index, (slide, _)) in flow.enumerated() {
             let renderer = ImageRenderer(
-                content: ScaleEffectView(width: 1920, height: 1080) {
+                content: ScaleEffectView(size: size) {
                     slide.createStaticView()
                         .background {
                             Color(T.deckStyle.colorStyle.backgroundColor)
                         }
                         .environment(\.fontStyle, T.deckStyle.fontStyle.self)
                         .environment(\.colorStyle, T.deckStyle.colorStyle.self)
+                        .environment(\.slideSize, size)
                 }
                 .frame(width: 192 * 3, height: 108 * 3)
             )

--- a/Sources/SwiftDex/Core/Deck/DeckView.swift
+++ b/Sources/SwiftDex/Core/Deck/DeckView.swift
@@ -48,7 +48,7 @@ public struct DeckView<T: Deck>: View {
 
     /// The body of the `DeckView` view.
     public var body: some View {
-        ScaleEffectView(width: 1920, height: 1080) {
+        ScaleEffectView(size: T.deckStyle.slideSize) {
             OverviewStage(controller: controller) {
                 presentation
             }
@@ -57,6 +57,7 @@ public struct DeckView<T: Deck>: View {
         .environment(\.matchProperties, matchedProperties)
         .environment(\.fontStyle, T.deckStyle.fontStyle)
         .environment(\.colorStyle, T.deckStyle.colorStyle)
+        .environment(\.slideSize, T.deckStyle.slideSize)
     }
 }
 
@@ -66,7 +67,7 @@ private extension DeckView {
     /// The live presentation surface: the current slide with tap and arrow-key
     /// navigation, transitioning between slides.
     var presentation: some View {
-        ScaleEffectView(width: 1920, height: 1080) {
+        ScaleEffectView(size: T.deckStyle.slideSize) {
             TapHandlerView {
                 currentView
                     .background {

--- a/Sources/SwiftDex/Core/Deck/ScaleEffectView.swift
+++ b/Sources/SwiftDex/Core/Deck/ScaleEffectView.swift
@@ -1,19 +1,25 @@
 import SwiftUI
 
 struct ScaleEffectView<Content: View>: View {
-    let width: CGFloat
-    let height: CGFloat
+    let size: CGSize
     @ViewBuilder let content: () -> Content
+
+    init(size: CGSize, @ViewBuilder content: @escaping () -> Content) {
+        self.size = size
+        self.content = content
+    }
 
     var body: some View {
         GeometryReader { proxy in
-            let ratio: CGFloat = width / height
-            let size = proxy.size
-            let scale = size.width > size.height * ratio ? size.height / height : size.width / width
+            let ratio = size.width / size.height
+            let proxySize = proxy.size
+            let scale =
+                proxySize.width > proxySize.height * ratio
+                ? proxySize.height / size.height : proxySize.width / size.width
             Color(.clear)
                 .overlay(
                     content()
-                        .frame(width: width, height: height)
+                        .frame(width: size.width, height: size.height)
                         .scaleEffect(
                             CGSize(width: scale, height: scale)
                         )

--- a/Sources/SwiftDex/Core/Slide/ZoomView/ZoomView.swift
+++ b/Sources/SwiftDex/Core/Slide/ZoomView/ZoomView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ZoomView<Content: View>: View {
     @EnvironmentObject private var elementAnchors: ElementAnchors
+    @Environment(\.slideSize) private var slideSize
 
     private let content: () -> Content
 
@@ -21,7 +22,7 @@ struct ZoomView<Content: View>: View {
                     // anchors keep resolving in untransformed slide coordinates and a
                     // later zoom target is not distorted by the current zoom.
                     ZoomEffect(
-                        baseRect: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+                        baseRect: CGRect(origin: .zero, size: slideSize),
                         targetRect: targetRect(for: progress, proxy: proxy)
                     )
                     .ignoredByLayout()
@@ -45,7 +46,7 @@ private extension ZoomView {
             rect = proxy[anchor]
         }
         else {
-            rect = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+            rect = CGRect(origin: .zero, size: slideSize)
         }
 
         let xInset = (rect.width / zoom.ratio - rect.width) / 2

--- a/Sources/SwiftDex/Preview/SlidePreview.swift
+++ b/Sources/SwiftDex/Preview/SlidePreview.swift
@@ -37,6 +37,7 @@ public struct SlidePreview<T: Slide, S: DeckStyle>: View {
             content
                 .environment(\.fontStyle, deckStyle.fontStyle.self)
                 .environment(\.colorStyle, deckStyle.colorStyle.self)
+                .environment(\.slideSize, deckStyle.slideSize)
         }
     }
 }
@@ -55,7 +56,7 @@ private extension SlidePreview {
     }
 
     var content: some View {
-        ScaleEffectView(width: 1920, height: 1080) {
+        ScaleEffectView(size: deckStyle.slideSize) {
             TapHandlerView {
                 SlideView(
                     slide: slide,
@@ -108,7 +109,8 @@ private extension SlidePreview {
     }
 
     func staticContent(step: Int) -> some View {
-        ScaleEffectView(width: 1920, height: 1080) {
+        let size = deckStyle.slideSize
+        return ScaleEffectView(size: size) {
             SlideView(
                 slide: slide,
                 step: step
@@ -118,6 +120,7 @@ private extension SlidePreview {
             }
             .environment(\.fontStyle, deckStyle.fontStyle.self)
             .environment(\.colorStyle, deckStyle.colorStyle.self)
+            .environment(\.slideSize, size)
         }
         .frame(width: 192 * 3, height: 108 * 3)
     }

--- a/Sources/SwiftDex/Style/DeckStyle.swift
+++ b/Sources/SwiftDex/Style/DeckStyle.swift
@@ -1,9 +1,12 @@
+import SwiftUI
+
 /// `DeckStyle` is a protocol for setting a style that is shared across the entire Deck.
 ///
 /// Define a custom `DeckStyle` and specify it from the `deckStyle` of the `Deck` protocol.
 public protocol DeckStyle {
     static var fontStyle: FontStyle.Type { get }
     static var colorStyle: ColorStyle.Type { get }
+    static var slideSize: CGSize { get }
 }
 
 public extension DeckStyle {
@@ -20,7 +23,22 @@ public extension DeckStyle {
     static var colorStyle: ColorStyle.Type {
         DefaultColorStyle.self
     }
+
+    static var slideSize: CGSize {
+        CGSize(width: 1920, height: 1080)
+    }
 }
 
 /// A default implementation of the `DeckStyle` protocol.
 public struct DefaultDeckStyle: DeckStyle {}
+
+struct SlideSizeKey: EnvironmentKey {
+    static let defaultValue: CGSize = DefaultDeckStyle.slideSize
+}
+
+extension EnvironmentValues {
+    var slideSize: CGSize {
+        get { self[SlideSizeKey.self] }
+        set { self[SlideSizeKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `slideSize` property to `DeckStyle` protocol (default: 1920×1080) so decks can declare a custom logical canvas size in one place
- Propagate `slideSize` through `EnvironmentValues` so deep views like `ZoomView` can read it without parameter drilling
- Refactor `ScaleEffectView` to accept `CGSize` directly instead of separate width/height parameters

## Test plan
- [x] `swift build` passes
- [x] `swift test` — all 46 tests pass
- [x] `make lint` clean
- [ ] Run example app and verify presentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)