### PR TITLE
Add SlideValueStore and @SlideValue for cross-window slide state

### DIFF
--- a/Sources/SwiftDex/Core/Deck/DeckController.swift
+++ b/Sources/SwiftDex/Core/Deck/DeckController.swift
@@ -27,6 +27,13 @@ public final class DeckController {
     /// Cached slide thumbnails, generated once at init.
     @ObservationIgnored private(set) var thumbnails: [Int: NSImage] = [:]
 
+    /// Slide-local shared state (`@SlideValue`), observed by every surface.
+    ///
+    /// Values survive only forward movement within one slide; every other
+    /// operation clears the store so rewinds stay deterministic. The store is
+    /// its own observable authority — the controller only owns its lifetime.
+    @ObservationIgnored let slideValueStore = SlideValueStore()
+
     /// Creates a controller for the given deck.
     ///
     /// - Parameters:
@@ -80,6 +87,7 @@ public final class DeckController {
             state.position = .click(state.currentClick + 1)
         }
         else if slideNumber < flow.count - 1 {
+            slideValueStore.clear()
             withAnimation(transitionAnimation) {
                 slideNumber += 1
                 slideID = UUID()
@@ -94,9 +102,11 @@ public final class DeckController {
         state.latestUserOperation = .backward
 
         if state.currentClick > 0 {
+            slideValueStore.clear()
             state.position = .click(state.currentClick - 1)
         }
         else if slideNumber > 0 {
+            slideValueStore.clear()
             slideNumber -= 1
             state = SlideState(
                 actionContainer: flow[slideNumber].0.actionContainer,
@@ -113,6 +123,7 @@ public final class DeckController {
         else {
             return
         }
+        slideValueStore.clear()
         self.slideNumber = slideNumber
         state = SlideState(actionContainer: flow[slideNumber].0.actionContainer)
         state.latestUserOperation = .randomAccess

--- a/Sources/SwiftDex/Core/Deck/DeckView.swift
+++ b/Sources/SwiftDex/Core/Deck/DeckView.swift
@@ -55,6 +55,7 @@ public struct DeckView<T: Deck>: View {
         }
         .environment(\.namespaceID, deckNamespace)
         .environment(\.matchProperties, matchedProperties)
+        .environment(\.slideValueStore, controller.slideValueStore)
         .environment(\.fontStyle, T.deckStyle.fontStyle)
         .environment(\.colorStyle, T.deckStyle.colorStyle)
         .environment(\.slideSize, T.deckStyle.slideSize)

--- a/Sources/SwiftDex/Core/RenderingEnvironment.swift
+++ b/Sources/SwiftDex/Core/RenderingEnvironment.swift
@@ -10,3 +10,25 @@ extension EnvironmentValues {
         set { self[StaticRenderingKey.self] = newValue }
     }
 }
+
+private struct IsMirrorKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+public extension EnvironmentValues {
+    /// Whether this surface mirrors a presentation that is primarily shown
+    /// elsewhere (e.g. a presenter display echoing the audience window).
+    ///
+    /// Views can read this to reduce rendering cost or substitute content
+    /// that cannot exist on two surfaces at once. Set it on a secondary
+    /// `DeckView`:
+    ///
+    /// ```swift
+    /// DeckView(deck: deck, controller: controller)
+    ///     .environment(\.isMirror, true)
+    /// ```
+    var isMirror: Bool {
+        get { self[IsMirrorKey.self] }
+        set { self[IsMirrorKey.self] = newValue }
+    }
+}

--- a/Sources/SwiftDex/Core/SlideValue/SlideValue.swift
+++ b/Sources/SwiftDex/Core/SlideValue/SlideValue.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// A property wrapper for slide-local state that stays in sync across every
+/// window presenting the same deck.
+///
+/// Use it in place of `@State` inside a custom view when the state should be
+/// shared between the presentation window and its mirrors (e.g. a presenter
+/// display). The value is keyed by the view's `ElementID`:
+///
+/// ```swift
+/// struct CounterView: View {
+///     @SlideValue private var count = 0
+///
+///     var body: some View {
+///         Button("\(count)") { count += 1 }
+///     }
+/// }
+///
+/// // In the slide:
+/// CounterView()
+///     .elementID(.element(0))
+/// ```
+///
+/// Without an `ElementID` (or outside a `DeckView`), the wrapper falls back
+/// to plain view-local state and nothing is shared.
+///
+/// The value lives only while the presentation moves forward within the
+/// current slide. Going backward, jumping to another slide, or any slide
+/// transition resets it, so rewinds stay deterministic.
+@propertyWrapper
+public struct SlideValue<Value>: DynamicProperty {
+    @Environment(\.elementID) private var elementID
+    @Environment(\.slideValueStore) private var store
+
+    @State private var localValue: Value
+    private let initialValue: Value
+
+    /// Creates the slide value with an initial value.
+    public init(wrappedValue: Value) {
+        self.initialValue = wrappedValue
+        self._localValue = State(initialValue: wrappedValue)
+    }
+
+    /// The current value, shared across surfaces when an `ElementID` is set.
+    public var wrappedValue: Value {
+        get {
+            if let store, elementID != .none {
+                return store.value(of: Value.self, for: elementID) ?? initialValue
+            }
+            return localValue
+        }
+        nonmutating set {
+            if let store, elementID != .none {
+                store.setValue(newValue, for: elementID)
+            }
+            else {
+                localValue = newValue
+            }
+        }
+    }
+
+    /// A binding to the value, for handing to controls.
+    public var projectedValue: Binding<Value> {
+        Binding(
+            get: { wrappedValue },
+            set: { wrappedValue = $0 }
+        )
+    }
+}

--- a/Sources/SwiftDex/Core/SlideValue/SlideValueStore.swift
+++ b/Sources/SwiftDex/Core/SlideValue/SlideValueStore.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// A store for slide-local element state, shared by every surface observing
+/// the same `DeckController`.
+///
+/// Values survive only forward movement within one slide: any backward step,
+/// random access, or slide transition clears the store, so a rewound or
+/// re-entered slide renders exactly as it did on first entry.
+///
+/// Entries are keyed by `(ElementID, value type)`, mirroring the action
+/// system's rule that an element's identity is its `ElementID`.
+@Observable
+final class SlideValueStore {
+    private var storage: [Key: Any] = [:]
+
+    private struct Key: Hashable {
+        let elementID: ElementID
+        let valueType: ObjectIdentifier
+    }
+
+    func value<Value>(of type: Value.Type, for elementID: ElementID) -> Value? {
+        storage[Key(elementID: elementID, valueType: ObjectIdentifier(type))] as? Value
+    }
+
+    func setValue<Value>(_ value: Value, for elementID: ElementID) {
+        storage[Key(elementID: elementID, valueType: ObjectIdentifier(Value.self))] = value
+    }
+
+    func clear() {
+        guard !storage.isEmpty else {
+            return
+        }
+        storage.removeAll()
+    }
+}
+
+private struct SlideValueStoreKey: EnvironmentKey {
+    static let defaultValue: SlideValueStore? = nil
+}
+
+extension EnvironmentValues {
+    var slideValueStore: SlideValueStore? {
+        get { self[SlideValueStoreKey.self] }
+        set { self[SlideValueStoreKey.self] = newValue }
+    }
+}

--- a/Tests/SwiftDexTests/Core/SlideValueStoreTests.swift
+++ b/Tests/SwiftDexTests/Core/SlideValueStoreTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import SwiftUI
+import XCTest
+
+@testable import SwiftDex
+
+@MainActor
+final class SlideValueStoreTests: XCTestCase {
+    func test_value_roundTrip() {
+        let store = SlideValueStore()
+        XCTAssertNil(store.value(of: Int.self, for: .element(0)))
+
+        store.setValue(42, for: .element(0))
+        XCTAssertEqual(store.value(of: Int.self, for: .element(0)), 42)
+    }
+
+    func test_keys_are_scoped_by_type_and_element() {
+        let store = SlideValueStore()
+        store.setValue(1, for: .element(0))
+        store.setValue("a", for: .element(0))
+        store.setValue(2, for: .element(1))
+
+        XCTAssertEqual(store.value(of: Int.self, for: .element(0)), 1)
+        XCTAssertEqual(store.value(of: String.self, for: .element(0)), "a")
+        XCTAssertEqual(store.value(of: Int.self, for: .element(1)), 2)
+    }
+
+    func test_forward_within_slide_keeps_values() {
+        let controller = DeckController(deck: StoreDeck())
+        controller.slideValueStore.setValue(42, for: .element(0))
+
+        // Slide 0 has two one-click actions; this forward stays on the slide.
+        controller.forward()
+        XCTAssertEqual(controller.slideNumber, 0)
+        XCTAssertEqual(controller.slideValueStore.value(of: Int.self, for: .element(0)), 42)
+    }
+
+    func test_forward_across_slides_clears() {
+        let controller = DeckController(deck: StoreDeck(), slideNumber: 1)
+        controller.slideValueStore.setValue(42, for: .element(0))
+
+        // Slide 1 has no actions, so this forward transitions to slide 2.
+        controller.forward()
+        XCTAssertEqual(controller.slideNumber, 2)
+        XCTAssertNil(controller.slideValueStore.value(of: Int.self, for: .element(0)))
+    }
+
+    func test_backward_clears() {
+        let controller = DeckController(deck: StoreDeck())
+        controller.forward()
+        controller.slideValueStore.setValue(42, for: .element(0))
+
+        // Rewinding a click within the slide discards state.
+        controller.backward()
+        XCTAssertEqual(controller.slideNumber, 0)
+        XCTAssertNil(controller.slideValueStore.value(of: Int.self, for: .element(0)))
+    }
+
+    func test_backward_across_slides_clears() {
+        let controller = DeckController(deck: StoreDeck(), slideNumber: 1)
+        controller.slideValueStore.setValue(42, for: .element(0))
+
+        controller.backward()
+        XCTAssertEqual(controller.slideNumber, 0)
+        XCTAssertNil(controller.slideValueStore.value(of: Int.self, for: .element(0)))
+    }
+
+    func test_randomAccess_clears() {
+        let controller = DeckController(deck: StoreDeck())
+        controller.slideValueStore.setValue(42, for: .element(0))
+
+        controller.randomAccess(slideNumber: 2)
+        XCTAssertNil(controller.slideValueStore.value(of: Int.self, for: .element(0)))
+    }
+}
+
+private struct StoreDeck: Deck {
+    var flow: some Flow {
+        ActionSlide()
+            .next(PlainSlide())
+            .next(PlainSlide())
+    }
+}
+
+private struct ActionSlide: Slide {
+    var content: some View {
+        EmptyView()
+            .elementID(.element(0))
+    }
+
+    @ActionContainerBuilder
+    var actionContainer: ActionContainer {
+        FakeAction(elementID: .element(0))
+        FakeAction1(elementID: .element(0))
+    }
+}
+
+private struct PlainSlide: Slide {
+    var content: some View {
+        EmptyView()
+    }
+}


### PR DESCRIPTION
## Summary

First half of the mirror/sync design ([design discussion](https://github.com/hagmas/swift-dex/pull/30)): the mechanism that lets custom-view state sync across windows sharing one `DeckController`.

- **`SlideValueStore`** (internal) — an `@Observable` KV store keyed by `(ElementID, value type)`. Owned by `DeckController` (`@ObservationIgnored`, internal — never appears in the public API) and injected by `DeckView` through an internal environment key, so both windows read the same instance.
- **`@SlideValue`** (public) — drop-in replacement for `@State` in custom views. With an `ElementID` set, reads/writes go to the shared store; without one, it falls back to view-local `@State` and nothing syncs.
- **Lifecycle** — values survive only forward movement within one slide. Backward (even within a slide), random access, and slide transitions clear the store, so rewinds stay deterministic and slides remain pure functions of `t`.
- **`\.isMirror`** (public) — environment primitive for surfaces that echo a presentation shown elsewhere; the base for future mirror strategies (snapshot, presentation-only, quality tiering).

## Test plan
- [x] `swift build` / `make lint`
- [x] 53/53 tests pass, including 7 new: store round-trip, type/element key scoping, keep-on-forward-within-slide, clear on cross-slide forward / backward (both kinds) / randomAccess
- [x] Example app builds
- [ ] `@SlideValue` end-to-end in a real two-window setup — lands with PR2 (VideoView), its first client

🤖 Generated with [Claude Code](https://claude.com/claude-code)