### PR TITLE
Add PlayVideo action

### DIFF
--- a/Examples/SwiftDexExample/Slides/CustomViews/AboutVideo.swift
+++ b/Examples/SwiftDexExample/Slides/CustomViews/AboutVideo.swift
@@ -8,7 +8,8 @@ struct AboutVideo: StandardLayoutSlide {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 32) {
-            "**VideoView** plays a video. Hover over it to reveal the playback controls."
+            "**VideoView** rests on its first frame until **PlayVideo** fires."
+            "Hover over it to reveal the playback controls."
             VideoView(name: "cat-chan", elementID: .video)
                 .aspectRatio(16 / 9, contentMode: .fit)
                 .cornerRadius(16)
@@ -16,10 +17,12 @@ struct AboutVideo: StandardLayoutSlide {
         }
     }
 
-    // A video is an ordinary element: it fades in, then zooms.
+    // A video is an ordinary element: the same identity takes Apply, PlayVideo,
+    // and Zoom, and playback keeps running across the later clicks.
     @ActionContainerBuilder
     var actionContainer: ActionContainer {
         Apply(.fade, to: .video)
+        PlayVideo(.video)
         Zoom(.in(.video, ratio: 0.8))
         Zoom(.out)
     }

--- a/Sources/SwiftDex/Action/PlayVideo.swift
+++ b/Sources/SwiftDex/Action/PlayVideo.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// An `Action` that starts playback of a `VideoView`.
+///
+/// The video waits on its first frame until this action fires, then plays on.
+/// Later clicks on the same slide do not interrupt it: playback is driven by
+/// the clock, not by the timeline. Leaving the slide or rewinding past this
+/// action discards the player, so the video starts over on re-entry.
+///
+/// Only the click that fires the action starts playback. Entering the slide
+/// backward leaves the video at rest on its first frame, since its elapsed
+/// time cannot be reconstructed from a click position.
+///
+/// ```swift
+/// VideoView(name: "demo", elementID: .video)
+/// ```
+/// ```swift
+/// @ActionContainerBuilder
+/// var actionContainer: ActionContainer {
+///     Apply(.fade, to: .video)
+///     PlayVideo(.video)
+/// }
+/// ```
+public struct PlayVideo: Action {
+    /// The `ElementID` of the `VideoView`.
+    public let elementID: ElementID
+
+    /// Create a new instance.
+    public init(_ elementID: ElementID) {
+        self.elementID = elementID
+    }
+}

--- a/Sources/SwiftDex/View/Video/VideoView.swift
+++ b/Sources/SwiftDex/View/Video/VideoView.swift
@@ -4,13 +4,21 @@ import SwiftUI
 /// A view that plays a video.
 ///
 /// Playback uses SwiftUI's native `VideoPlayer`, with hover-revealed controls.
+/// The video rests on its first frame until a ``PlayVideo`` action fires; from
+/// then on it plays on its own clock, undisturbed by later clicks.
+///
 /// Pass an `elementID` and the underlying `AVPlayer` is shared through
 /// `@SlideValue`: every window presenting the same deck drives one player, so
 /// there is a single audio stream and scrubbing on any surface moves all of
-/// them. Without an `elementID` the player is local to the view.
+/// them. Without an `elementID` the player is local to the view — and no
+/// action can reach it.
 ///
 /// The player follows the slide-value lifecycle: leaving the slide or rewinding
-/// discards it, so re-entry starts from the beginning.
+/// past the `PlayVideo` action discards it, so the video starts over.
+///
+/// Playback begins on the click that fires the action and on nothing else.
+/// Time cannot be rewound, so a slide entered backward shows the video at rest
+/// on its first frame even though its timeline sits past the play beat.
 ///
 /// ```swift
 /// VideoView(name: "demo", elementID: .video)
@@ -24,8 +32,8 @@ public struct VideoView: View {
     ///
     /// - Parameters:
     ///   - url: The video file to play.
-    ///   - elementID: The identity under which the shared `AVPlayer` is stored.
-    ///     Omit it to keep the player local to this view.
+    ///   - elementID: The identity actions target, and under which the shared
+    ///     `AVPlayer` is stored. Omit it to keep the player local to this view.
     public init(url: URL?, elementID: ElementID = .none) {
         self.url = url
         self.elementID = elementID
@@ -37,8 +45,8 @@ public struct VideoView: View {
     ///   - name: The name of the video file without its extension.
     ///   - fileExtension: The file extension. Defaults to `mp4`.
     ///   - bundle: The bundle containing the resource.
-    ///   - elementID: The identity under which the shared `AVPlayer` is stored.
-    ///     Omit it to keep the player local to this view.
+    ///   - elementID: The identity actions target, and under which the shared
+    ///     `AVPlayer` is stored. Omit it to keep the player local to this view.
     public init(
         name: String,
         fileExtension: String = "mp4",
@@ -52,13 +60,26 @@ public struct VideoView: View {
     /// The content and behavior of the view.
     public var body: some View {
         if let url {
-            // `@SlideValue` reads its identity from the environment, which a
-            // view cannot write for its own stored properties — hence the
-            // private child.
-            VideoPlayerView(url: url)
-                .environment(\.elementID, elementID)
-                .modifier(ElementAnimator(elementID: elementID))
+            ActionReader(PlayVideo.self, elementID: elementID, clicks: 1) { progress in
+                // `@SlideValue` reads its identity from the environment, which a
+                // view cannot write for its own stored properties — hence the
+                // private child.
+                VideoPlayerView(url: url, hasFired: progress.hasFired)
+            }
+            .environment(\.elementID, elementID)
         }
+    }
+}
+
+private extension ActionProgress<PlayVideo> {
+    /// Whether the timeline sits at or beyond the play beat.
+    ///
+    /// `nearestAction` is the action running, completed, or most recently
+    /// passed. This is a level, not an event: it is equally true on the click
+    /// that fires the action, on a slide entered backward, and while the slide
+    /// transitions away. Only its rising edge means "start playing".
+    var hasFired: Bool {
+        nearestAction != nil
     }
 }
 
@@ -67,27 +88,38 @@ private struct VideoPlayerView: View {
     @SlideValue private var player: AVPlayer? = nil
 
     let url: URL
+    let hasFired: Bool
 
     var body: some View {
         if isStaticRendering {
             placeholder
         }
         else {
-            VideoPlayer(player: resolvedPlayer())
+            VideoPlayer(player: player)
+                // Creating the player is a store write, so it must not happen
+                // during body evaluation. Keying on its absence also covers the
+                // slide value being cleared out from under this view — by a
+                // rewind, or by leaving the slide while it is still on screen
+                // for the transition. A new player is never started here: that
+                // would give the departing slide a second of audio, and would
+                // start playback on a slide entered backward.
+                .onChange(of: player == nil, initial: true) { _, isMissing in
+                    if isMissing {
+                        player = AVPlayer(url: url)
+                    }
+                }
+                // Playback follows the rising edge of the action, not the
+                // timeline's position relative to it. Time cannot be rewound,
+                // so a video reached by any route other than clicking onto its
+                // beat rests on its first frame.
+                .onChange(of: hasFired) { _, hasFired in
+                    hasFired ? player?.play() : player?.pause()
+                }
         }
     }
 }
 
 private extension VideoPlayerView {
-    func resolvedPlayer() -> AVPlayer {
-        if let player {
-            return player
-        }
-        let created = AVPlayer(url: url)
-        player = created
-        return created
-    }
-
     /// Stands in for the player where an `NSView` cannot be captured —
     /// `ImageRenderer` thumbnails and overview transitions.
     var placeholder: some View {


### PR DESCRIPTION
## Summary

A `VideoView` now rests on its first frame until a `PlayVideo` action fires:

```swift
VideoView(name: "demo", elementID: .video)
```
```swift
@ActionContainerBuilder
var actionContainer: ActionContainer {
    Apply(.fade, to: .video)
    PlayVideo(.video)
    Zoom(.in(.video, ratio: 0.8))
    Zoom(.out)
}
```

The action is the smallest shape that works — one click, one element. No pause or seek variants: manual control already exists on hover, and #34 was a reminder not to design API around cases that haven't shown up yet.

`VideoView` reaches its own action through `ActionReader`, which also installs the `Apply` path, so the explicit `ElementAnimator` it carried since #34 is gone. The same identity now takes `Apply`, `PlayVideo` and `Zoom`, and playback runs on undisturbed across the later clicks.

## Playback follows the edge, not the level

`hasFired` (the timeline is at or beyond the play beat) is a level. Two places make it true where nothing should start:

- a slide **entered backward** lands past the play beat;
- a slide **being left** keeps its view on screen for the transition, while `SlideValueStore` clears the player out from under it.

The first draft started a freshly created player whenever `hasFired` was true, which leaked a second of audio behind the outgoing transition and replayed the video on the way back. Creating a player now never starts it; playback is triggered only by the rising edge of `hasFired`, which within a view's lifetime can only be the click onto its beat.

Consequence worth knowing: a video reached by any route other than clicking onto its beat rests on its first frame, even though the timeline sits past the action. Elapsed time cannot be reconstructed from a click position, and silence is the safer failure.

## Also

Player creation moved out of body evaluation — writing to the observable `SlideValueStore` there was a state mutation during view update.

## Test plan
- [x] `swift build` / `make lint` / 53 tests pass
- [x] Example app builds, no runtime state-mutation warnings
- [x] fade → play → zoom in → zoom out, playback continuing through the zooms (AboutVideo)
- [x] No audio behind the transition when advancing to the next slide
- [x] Returning to the slide leaves the video at rest on its first frame
- [x] Rewinding before the play beat and advancing again starts playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)