### PR TITLE
Let a slide be larger than the viewport

### DIFF
--- a/Examples/SwiftDexExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftDexExample.xcodeproj/project.pbxproj
@@ -15,13 +15,14 @@
 		4EE5D8E416520127DA6F5D70 /* AboutVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92EAAC09884A32CAE39BD3F /* AboutVideo.swift */; };
 		5E3C4AA34F26864C37D057F6 /* AboutApply.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93EE49FF7DB4060675933EB /* AboutApply.swift */; };
 		74A3546B6459532D9FC788BB /* SwiftDex in Frameworks */ = {isa = PBXBuildFile; productRef = 901786E0D97D642D5C0CE960 /* SwiftDex */; };
-		7B8070A3DC8BFF06CF1A9C70 /* AboutCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6189BF1512A381102BFFF88 /* AboutCamera.swift */; };
 		7C59F47B5CE1149B8F6AC137 /* AboutHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475CCF49FCB2BA35E7BCCDE9 /* AboutHighlight.swift */; };
 		843D04C0705EB393C7D59C55 /* AboutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33E50F3C38B6DA824A966BB /* AboutAction.swift */; };
 		864818E5202D35F51C508736 /* AboutTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C23E7D5C1B84F8C87E8CC6 /* AboutTransition.swift */; };
 		93912B3C4425A6203FC96450 /* SwiftDexExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD7255273A93DB0FEF98C81 /* SwiftDexExampleApp.swift */; };
 		9EEB0775B7A3BA87A421DCED /* cat-chan.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 69FE6C82C9FB80970BECBC0B /* cat-chan.mp4 */; };
 		9EEC10946E592DFFAEA1B03A /* Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F9F0DDDBC33B4282CCF9D7 /* Title.swift */; };
+		A4E6B9E1E4B119B86B82B3CC /* AboutCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8FABFC622AE7F16B6E6369 /* AboutCanvas.swift */; };
+		A630495F7221A70D0491741C /* AboutCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6339A7901B60017B74729B89 /* AboutCamera.swift */; };
 		B6DAA2601DFD8504C4C0FD62 /* Layout2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A17BC3CB6C02ADB509A76B /* Layout2.swift */; };
 		BAD7307B15C35E37802F5B0A /* AboutGif.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AAA59F86D1C76DAB2E17E /* AboutGif.swift */; };
 		C29F40A2A5A65127AC2464DE /* cat-chan.gif in Resources */ = {isa = PBXBuildFile; fileRef = CA2840DB24E3B23FD1430E35 /* cat-chan.gif */; };
@@ -45,12 +46,12 @@
 		475CCF49FCB2BA35E7BCCDE9 /* AboutHighlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutHighlight.swift; sourceTree = "<group>"; };
 		4D5ACA3638B63FD73584EC5A /* AboutBullets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutBullets.swift; sourceTree = "<group>"; };
 		5BD7255273A93DB0FEF98C81 /* SwiftDexExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDexExampleApp.swift; sourceTree = "<group>"; };
+		6339A7901B60017B74729B89 /* AboutCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutCamera.swift; sourceTree = "<group>"; };
 		69FE6C82C9FB80970BECBC0B /* cat-chan.mp4 */ = {isa = PBXFileReference; path = "cat-chan.mp4"; sourceTree = "<group>"; };
 		6F87C8689A0B703A15C957B7 /* SlideTransition+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SlideTransition+Extensions.swift"; sourceTree = "<group>"; };
 		87F497EC9F50CC1B8B8B813C /* Introduction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Introduction.swift; sourceTree = "<group>"; };
 		AAC5BDDB4254D1D61F5EAEE8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B1F9F0DDDBC33B4282CCF9D7 /* Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Title.swift; sourceTree = "<group>"; };
-		B6189BF1512A381102BFFF88 /* AboutCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutCamera.swift; sourceTree = "<group>"; };
 		B727C7891235FBB7D368C4A9 /* AboutStandardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutStandardLayout.swift; sourceTree = "<group>"; };
 		C0A17BC3CB6C02ADB509A76B /* Layout2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Layout2.swift; sourceTree = "<group>"; };
 		C2C23E7D5C1B84F8C87E8CC6 /* AboutTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTransition.swift; sourceTree = "<group>"; };
@@ -60,6 +61,7 @@
 		E92EAAC09884A32CAE39BD3F /* AboutVideo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutVideo.swift; sourceTree = "<group>"; };
 		EC28170B7BB8A2D53CEF3B2E /* swift-dex */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-dex"; path = ..; sourceTree = SOURCE_ROOT; };
 		F33E50F3C38B6DA824A966BB /* AboutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutAction.swift; sourceTree = "<group>"; };
+		FA8FABFC622AE7F16B6E6369 /* AboutCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutCanvas.swift; sourceTree = "<group>"; };
 		FE46BC7FF2F4B42204668B45 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		FF13D146E4ACED0DFA40779D /* AboutCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutCode.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -90,9 +92,10 @@
 			children = (
 				F33E50F3C38B6DA824A966BB /* AboutAction.swift */,
 				C93EE49FF7DB4060675933EB /* AboutApply.swift */,
+				6339A7901B60017B74729B89 /* AboutCamera.swift */,
+				FA8FABFC622AE7F16B6E6369 /* AboutCanvas.swift */,
 				475CCF49FCB2BA35E7BCCDE9 /* AboutHighlight.swift */,
 				C2C23E7D5C1B84F8C87E8CC6 /* AboutTransition.swift */,
-				B6189BF1512A381102BFFF88 /* AboutCamera.swift */,
 			);
 			path = CustomAnimation;
 			sourceTree = "<group>";
@@ -277,6 +280,8 @@
 				843D04C0705EB393C7D59C55 /* AboutAction.swift in Sources */,
 				5E3C4AA34F26864C37D057F6 /* AboutApply.swift in Sources */,
 				FF553C08AE1066CD81EEC06A /* AboutBullets.swift in Sources */,
+				A630495F7221A70D0491741C /* AboutCamera.swift in Sources */,
+				A4E6B9E1E4B119B86B82B3CC /* AboutCanvas.swift in Sources */,
 				1BFBA7EA6EB6F6A3B5274EA5 /* AboutCode.swift in Sources */,
 				FA85639F5460A873A20083FC /* AboutFlipper.swift in Sources */,
 				BAD7307B15C35E37802F5B0A /* AboutGif.swift in Sources */,
@@ -284,7 +289,6 @@
 				32EB5D9C7CA555D972C8AA19 /* AboutStandardLayout.swift in Sources */,
 				864818E5202D35F51C508736 /* AboutTransition.swift in Sources */,
 				4EE5D8E416520127DA6F5D70 /* AboutVideo.swift in Sources */,
-				7B8070A3DC8BFF06CF1A9C70 /* AboutCamera.swift in Sources */,
 				2A964C936EFFD3FD4FB87D13 /* ContentView.swift in Sources */,
 				CB1687152630DD3D402B3497 /* ElementTransition+Extensions.swift in Sources */,
 				41EDA80C0FB3207CFE8ED445 /* Introduction.swift in Sources */,

--- a/Examples/SwiftDexExample/MyDeck.swift
+++ b/Examples/SwiftDexExample/MyDeck.swift
@@ -18,6 +18,7 @@ private extension MyDeck {
             .next(AboutAction(), transition: .customPush())
             .next(AboutApply(), transition: .customPush())
             .next(AboutCamera(), transition: .customPush())
+            .next(AboutCanvas(), transition: .customPush())
             .next(AboutTransition(), transition: .customPush())
             .next(AboutHighlight(), transition: .customPush())
     }

--- a/Examples/SwiftDexExample/Slides/CustomAnimation/AboutCanvas.swift
+++ b/Examples/SwiftDexExample/Slides/CustomAnimation/AboutCanvas.swift
@@ -1,0 +1,89 @@
+import SwiftDex
+import SwiftUI
+
+struct AboutCanvas: Slide {
+    // Three viewports wide. The height is left alone, so the slide is exactly
+    // as tall as every other one.
+    var canvas: SlideCanvas {
+        .init(width: .points(1920 * 3))
+    }
+
+    var content: some View {
+        HStack(spacing: 0) {
+            Element(.element(0)) {
+                panel(
+                    number: "1",
+                    title: "A slide can be wider than the screen",
+                    color: .cyan
+                ) {
+                    "Give a slide a **`canvas`** and it keeps laying out past the edge of the viewport."
+                }
+            }
+            Element(.element(1)) {
+                panel(
+                    number: "2",
+                    title: "The camera travels over it",
+                    color: .mint
+                ) {
+                    "**`Camera(.pan(to:))`** moves the viewport onto an element without changing the zoom level."
+                }
+            }
+            Element(.element(2)) {
+                panel(
+                    number: "3",
+                    title: "Both axes are independent",
+                    color: .pink
+                ) {
+                    "Each axis is **`.slide`**, **`.points`**, or **`.content`**."
+                    Element(.element(10)) {
+                        "`.content` sizes the axis to whatever the slide lays out."
+                            .textStyle(.caption)
+                            .padding(24)
+                            .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 16))
+                    }
+                }
+            }
+        }
+    }
+
+    // Two pans across the canvas at the home zoom level, then a zoom into an
+    // element small enough that only the camera can reach it, and home again.
+    @ActionContainerBuilder
+    var actionContainer: ActionContainer {
+        Camera(.pan(to: .element(1)))
+        Camera(.pan(to: .element(2)))
+        Camera(.zoom(to: .element(10), ratio: 0.7))
+        Camera(.reset)
+    }
+}
+
+private extension AboutCanvas {
+    @ViewBuilder
+    func panel(
+        number: String,
+        title: String,
+        color: Color,
+        @ViewBuilder detail: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 40) {
+            number
+                .textStyle(.title)
+                .foregroundStyle(color)
+            title
+                .textStyle(.subtitle)
+            detail()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(80)
+        .overlay(alignment: .trailing) {
+            Rectangle()
+                .fill(.primary.opacity(0.1))
+                .frame(width: 2)
+        }
+    }
+}
+
+#Preview {
+    SlidePreview(slide: AboutCanvas())
+}

--- a/Sources/SwiftDex/Core/Slide/CameraView/CameraEffect.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraView/CameraEffect.swift
@@ -9,6 +9,14 @@ import SwiftUI
 struct CameraEffect: GeometryEffect {
     var rect: CGRect
 
+    /// The size of the surface the camera maps onto.
+    ///
+    /// Passed in rather than taken from `effectValue(size:)`, whose `size` is
+    /// the size of the view being transformed — on a canvas slide that is the
+    /// canvas, not the viewport. The two coincide only when a slide is exactly
+    /// as large as the screen.
+    let viewport: CGSize
+
     var animatableData: CGRect.AnimatableData {
         get {
             CGRect.AnimatableData(
@@ -31,10 +39,10 @@ struct CameraEffect: GeometryEffect {
             return ProjectionTransform()
         }
 
-        let scale = min(size.width / rect.width, size.height / rect.height)
+        let scale = min(viewport.width / rect.width, viewport.height / rect.height)
         return ProjectionTransform(
             CGAffineTransform.identity
-                .translatedBy(x: size.width / 2, y: size.height / 2)
+                .translatedBy(x: viewport.width / 2, y: viewport.height / 2)
                 .scaledBy(x: scale, y: scale)
                 .translatedBy(x: -rect.midX, y: -rect.midY)
         )

--- a/Sources/SwiftDex/Core/Slide/CameraView/CameraView.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraView/CameraView.swift
@@ -1,15 +1,13 @@
 import SwiftUI
 
-struct CameraView<Content: View>: View {
+struct CameraView<Content: View, Background: View>: View {
     @EnvironmentObject private var elementAnchors: ElementAnchors
     @Environment(AnySlideViewModel.self) private var slideViewModel
     @Environment(\.slideSize) private var slideSize
 
-    private let content: () -> Content
-
-    init(@ViewBuilder _ content: @escaping () -> Content) {
-        self.content = content
-    }
+    let canvas: SlideCanvas
+    @ViewBuilder let content: () -> Content
+    @ViewBuilder let background: () -> Background
 
     var body: some View {
         GeometryReader { proxy in
@@ -19,17 +17,14 @@ struct CameraView<Content: View>: View {
             // rectangle comes from the whole history, because `pan` is
             // relative to the operation before it.
             ActionReader(Camera.self, elementID: .none, clicks: 1) { progress in
-                ZStack(alignment: .topLeading) {
-                    content()
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                .modifier(
-                    // `ignoredByLayout` keeps the camera transform out of layout, so
-                    // anchors keep resolving in untransformed slide coordinates and a
-                    // later target is not distorted by where the camera is now.
-                    CameraEffect(rect: cameraRect(proxy: proxy))
-                        .ignoredByLayout()
-                )
+                canvasContent
+                    .modifier(
+                        // `ignoredByLayout` keeps the camera transform out of layout, so
+                        // anchors keep resolving in untransformed canvas coordinates and a
+                        // later target is not distorted by where the camera is now.
+                        CameraEffect(rect: cameraRect(proxy: proxy), viewport: slideSize)
+                            .ignoredByLayout()
+                    )
             } animation: { progress in
                 progress.current != nil ? .spring() : nil
             }
@@ -39,6 +34,44 @@ struct CameraView<Content: View>: View {
 }
 
 private extension CameraView {
+    /// The slide laid out at its canvas size, pinned to the canvas origin.
+    ///
+    /// A `.content` axis is left unconstrained so the content takes its ideal
+    /// size on it. The canvas extent is therefore never measured: it is an
+    /// outcome of laying the content out, not an input to it, which is what
+    /// keeps a `.content` canvas renderable in one pass.
+    var canvasContent: some View {
+        ZStack(alignment: .topLeading) {
+            content()
+        }
+        .fixedSize(horizontal: canvas.width.isContent, vertical: canvas.height.isContent)
+        .frame(
+            width: canvas.width.length(slide: slideSize.width),
+            height: canvas.height.length(slide: slideSize.height),
+            alignment: .topLeading
+        )
+        // The background is applied to the laid-out canvas rather than stretched
+        // on its own, so it covers a `.content` canvas without being measured.
+        .background(alignment: .topLeading) {
+            background()
+        }
+        // Inside the camera transform, so the cutout travels with the content it
+        // is cut out of and needs no transform of its own. The dim covers the
+        // canvas; the area beyond a canvas edge is the deck's background.
+        .overlay {
+            HighlightView()
+        }
+        // Pin the canvas to the viewport's origin: the camera addresses it in
+        // coordinates that start at the canvas's top-left corner.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    /// The rectangle the camera returns to, and starts from.
+    ///
+    /// Deliberately the viewport at the canvas origin rather than anything
+    /// derived from the canvas: it is then known before the content has laid
+    /// out, so a thumbnail of a `.content` canvas is framed correctly on the
+    /// first pass.
     var home: CGRect {
         CGRect(origin: .zero, size: slideSize)
     }

--- a/Sources/SwiftDex/Core/Slide/Slide.swift
+++ b/Sources/SwiftDex/Core/Slide/Slide.swift
@@ -15,6 +15,13 @@ public protocol Slide: Flow {
     ///
     /// Define it using the `@ActionContainerBuilder` result builder.
     var actionContainer: ActionContainer { get }
+
+    /// The area this slide lays its content out in.
+    ///
+    /// Defaults to the viewport, which is the whole of the slide. A larger
+    /// canvas gives the slide room the viewport cannot show at once, reached
+    /// with `Camera`.
+    var canvas: SlideCanvas { get }
 }
 
 public extension Slide {
@@ -26,6 +33,11 @@ public extension Slide {
     /// Default value for `actionContainer`.
     var actionContainer: ActionContainer {
         ActionContainer.empty
+    }
+
+    /// Default value for `canvas`.
+    var canvas: SlideCanvas {
+        .slide
     }
 
     /// Default implemenation for `flatten()`.

--- a/Sources/SwiftDex/Core/Slide/SlideCanvas.swift
+++ b/Sources/SwiftDex/Core/Slide/SlideCanvas.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// The extent of one axis of a slide's canvas.
+public enum CanvasExtent: Equatable {
+    /// The deck's slide size: the extent the viewport itself has.
+    case slide
+
+    /// A fixed number of points.
+    case points(CGFloat)
+
+    /// Whatever the content lays out to on this axis.
+    ///
+    /// The axis is left unconstrained, so the content takes its ideal size —
+    /// which means content that stretches to `.infinity` on this axis has no
+    /// defined extent and cannot use it.
+    case content
+}
+
+/// The area a slide lays its content out in.
+///
+/// A canvas defaults to the viewport on both axes, which is what every slide
+/// that has never heard of one gets. Declaring a larger canvas gives a slide
+/// room the viewport cannot show at once; `Camera` is how the presentation
+/// travels over it.
+///
+/// ```swift
+/// struct SystemMap: Slide {
+///     var canvas: SlideCanvas { .init(width: .points(5760)) }   // three screens wide
+/// }
+/// ```
+///
+/// The axes are independent: a slide can be three screens wide and exactly one
+/// screen tall, or as tall as its content and no wider than the viewport.
+public struct SlideCanvas: Equatable {
+
+    /// The extent of the horizontal axis.
+    public var width: CanvasExtent
+
+    /// The extent of the vertical axis.
+    public var height: CanvasExtent
+
+    /// Create a new instance.
+    ///
+    /// - Parameters:
+    ///   - width: The extent of the horizontal axis. Defaults to the viewport's.
+    ///   - height: The extent of the vertical axis. Defaults to the viewport's.
+    public init(width: CanvasExtent = .slide, height: CanvasExtent = .slide) {
+        self.width = width
+        self.height = height
+    }
+
+    /// The canvas that matches the viewport exactly, on both axes.
+    public static let slide = SlideCanvas()
+}
+
+extension CanvasExtent {
+    /// The length to impose on this axis, or `nil` when the content decides it.
+    func length(slide: CGFloat) -> CGFloat? {
+        switch self {
+        case .slide:
+            slide
+
+        case .points(let points):
+            points
+
+        case .content:
+            nil
+        }
+    }
+
+    var isContent: Bool {
+        self == .content
+    }
+}

--- a/Sources/SwiftDex/Core/Slide/SlideView.swift
+++ b/Sources/SwiftDex/Core/Slide/SlideView.swift
@@ -36,13 +36,11 @@ struct SlideView<T>: View where T: Slide {
     }
 
     var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            CameraView {
-                slide.background
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                slide.content
-            }
-            HighlightView()
+        CameraView(canvas: slide.canvas) {
+            slide.content
+        } background: {
+            slide.background
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .environment(viewModel)
         .environmentObject(elementAnchors)

--- a/Tests/SwiftDexTests/Core/CameraTests.swift
+++ b/Tests/SwiftDexTests/Core/CameraTests.swift
@@ -7,6 +7,7 @@ import XCTest
 /// a rectangle, and the transform that maps that rectangle onto the viewport.
 final class CameraTests: XCTestCase {
     private let home = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+    private let viewport = CGSize(width: 1920, height: 1080)
 
     private let rects: [ElementID: CGRect] = [
         .element(0): CGRect(x: 100, y: 100, width: 200, height: 200),
@@ -117,20 +118,40 @@ final class CameraTests: XCTestCase {
     }
 
     func test_effectValue_putsTheCameraCentreAtTheViewportCentre() {
-        let size = CGSize(width: 1920, height: 1080)
         let rect = CGRect(x: 850, y: 350, width: 400, height: 400)
-        let transform = CameraEffect(rect: rect).effectValue(size: size)
+        let transform = CameraEffect(rect: rect, viewport: viewport)
+            .effectValue(size: viewport)
 
         let centre = apply(transform, to: CGPoint(x: rect.midX, y: rect.midY))
         XCTAssertEqual(centre.x, 960, accuracy: 0.001)
         XCTAssertEqual(centre.y, 540, accuracy: 0.001)
     }
 
+    func test_effectValue_ignoresTheSizeItIsHanded() {
+        // The transformed view is the canvas, so `size` is the canvas — three
+        // viewports wide here. Reading the viewport off it shifts the whole
+        // slide out of frame and mis-scales every zoom.
+        let rect = CGRect(x: 850, y: 350, width: 400, height: 400)
+        let effect = CameraEffect(rect: rect, viewport: viewport)
+
+        let onViewport = effect.effectValue(size: viewport)
+        let onCanvas = effect.effectValue(size: CGSize(width: 5760, height: 1080))
+
+        for point in [CGPoint.zero, CGPoint(x: 1050, y: 550), CGPoint(x: 5000, y: 900)] {
+            let a = apply(onViewport, to: point)
+            let b = apply(onCanvas, to: point)
+            XCTAssertEqual(a.x, b.x, accuracy: 0.001)
+            XCTAssertEqual(a.y, b.y, accuracy: 0.001)
+        }
+    }
+
     func test_effectValue_fitsOnTheTighterAxis() {
-        let size = CGSize(width: 1920, height: 1080)
         // 400×400 in a 16:9 viewport fits by height: scale 1080/400 = 2.7.
-        let transform = CameraEffect(rect: CGRect(x: 850, y: 350, width: 400, height: 400))
-            .effectValue(size: size)
+        let transform = CameraEffect(
+            rect: CGRect(x: 850, y: 350, width: 400, height: 400),
+            viewport: viewport
+        )
+        .effectValue(size: viewport)
 
         let topLeft = apply(transform, to: CGPoint(x: 850, y: 350))
         let bottomRight = apply(transform, to: CGPoint(x: 1250, y: 750))
@@ -139,8 +160,7 @@ final class CameraTests: XCTestCase {
     }
 
     func test_effectValue_atHomeIsTheIdentity() {
-        let size = CGSize(width: 1920, height: 1080)
-        let transform = CameraEffect(rect: home).effectValue(size: size)
+        let transform = CameraEffect(rect: home, viewport: viewport).effectValue(size: viewport)
 
         for point in [CGPoint.zero, CGPoint(x: 1920, y: 1080), CGPoint(x: 640, y: 800)] {
             let mapped = apply(transform, to: point)
@@ -150,7 +170,7 @@ final class CameraTests: XCTestCase {
     }
 
     func test_effectValue_degenerateRectIsTheIdentity() {
-        let transform = CameraEffect(rect: .zero).effectValue(size: CGSize(width: 1920, height: 1080))
+        let transform = CameraEffect(rect: .zero, viewport: viewport).effectValue(size: viewport)
         let mapped = apply(transform, to: CGPoint(x: 100, y: 200))
         XCTAssertEqual(mapped.x, 100, accuracy: 0.001)
         XCTAssertEqual(mapped.y, 200, accuracy: 0.001)

--- a/Tests/SwiftDexTests/Core/SlideCanvasTests.swift
+++ b/Tests/SwiftDexTests/Core/SlideCanvasTests.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import XCTest
+
+@testable import SwiftDex
+
+/// Tests for the canvas a slide lays its content out in.
+final class SlideCanvasTests: XCTestCase {
+    private let slideSize = CGSize(width: 1920, height: 1080)
+
+    // MARK: - Extents
+
+    func test_slideExtent_takesTheViewportsLength() {
+        XCTAssertEqual(CanvasExtent.slide.length(slide: slideSize.width), 1920)
+    }
+
+    func test_pointsExtent_takesTheGivenLength() {
+        XCTAssertEqual(CanvasExtent.points(5760).length(slide: slideSize.width), 5760)
+    }
+
+    func test_contentExtent_imposesNoLength() {
+        // `nil` is what leaves the axis unconstrained, so the content decides
+        // it. The extent is never measured back.
+        XCTAssertNil(CanvasExtent.content.length(slide: slideSize.width))
+        XCTAssertTrue(CanvasExtent.content.isContent)
+        XCTAssertFalse(CanvasExtent.slide.isContent)
+        XCTAssertFalse(CanvasExtent.points(5760).isContent)
+    }
+
+    // MARK: - The canvas
+
+    func test_canvas_defaultsToTheViewportOnBothAxes() {
+        XCTAssertEqual(SlideCanvas(), .slide)
+        XCTAssertEqual(SlideCanvas.slide.width, .slide)
+        XCTAssertEqual(SlideCanvas.slide.height, .slide)
+    }
+
+    func test_canvas_axesAreIndependent() {
+        let canvas = SlideCanvas(width: .points(5760))
+        XCTAssertEqual(canvas.width, .points(5760))
+        XCTAssertEqual(canvas.height, .slide, "an unspecified axis keeps the viewport's extent")
+        XCTAssertNotEqual(canvas, .slide)
+    }
+
+    // MARK: - The slide
+
+    private struct PlainSlide: Slide {
+        var content: some View { EmptyView() }
+    }
+
+    private struct WideSlide: Slide {
+        var canvas: SlideCanvas { .init(width: .points(5760)) }
+        var content: some View { EmptyView() }
+    }
+
+    private struct TallSlide: Slide {
+        var canvas: SlideCanvas { .init(height: .content) }
+        var content: some View { EmptyView() }
+    }
+
+    func test_slide_canvasDefaultsToTheViewport() {
+        // Every slide written before canvases existed keeps its behaviour.
+        XCTAssertEqual(PlainSlide().canvas, .slide)
+    }
+
+    func test_slide_declaredCanvasIsKept() {
+        XCTAssertEqual(WideSlide().canvas, SlideCanvas(width: .points(5760), height: .slide))
+        XCTAssertEqual(TallSlide().canvas, SlideCanvas(width: .slide, height: .content))
+    }
+}


### PR DESCRIPTION
Second of three PRs toward slides larger than the screen. #37 gave the viewport a camera; this gives it somewhere to go. Manual input is still PR3, so a canvas is reached only by `Camera` actions.

## What

A slide declares the area it lays its content out in, one axis at a time:

```swift
struct SystemMap: Slide {
    var canvas: SlideCanvas { .init(width: .points(5760)) }   // three screens wide, one tall
}

struct LongCode: Slide {
    var canvas: SlideCanvas { .init(height: .content) }       // as tall as the content needs
}
```

| extent | the axis |
|---|---|
| `.slide` | keeps the viewport's extent — the default, on both axes |
| `.points(n)` | is exactly `n` |
| `.content` | is left unconstrained, so the content decides it |

Both axes default to `.slide`, so every slide written before this one is untouched. There is no deck-wide mode: a canvas is opt-in per slide, and a deck can be forty ordinary slides with one wide one in the middle.

## `.content` is never measured

The axis is left unconstrained and the content takes its ideal size. The library does not read the resulting extent back anywhere — the canvas size is an outcome of laying the content out, never an input to it.

That is what keeps it renderable in one pass. Nothing waits on a measurement, so `ImageRenderer` needs no second layout cycle, and `home` is deliberately the viewport at the canvas origin rather than anything derived from the canvas, so it is known before the content has laid out at all.

The background is applied to the laid-out canvas rather than stretched on its own, which is how it covers a `.content` canvas without being measured either. Content that stretches to `.infinity` on a `.content` axis has no defined extent and cannot use it; that is documented on the case.

## The bug this surfaced

`CameraEffect` read the viewport off `effectValue(size:)`. That parameter is the size of the view being transformed, which on a canvas slide is the canvas:

```
effectValue size, content exactly the viewport   (1920, 1080)
effectValue size, content 3 viewports wide       (5760, 1080)   ← even behind .frame(maxWidth: .infinity)
```

The two had only ever coincided because a slide was always exactly as large as the screen. With a canvas it shifted the slide clean out of frame at home — a blank slide on arrival — and computed every zoom's fit against the wrong reference. The viewport is now passed in explicitly, and `test_effectValue_ignoresTheSizeItIsHanded` hands the same effect both sizes and requires the same answer.

## Highlight

`HighlightView` moves inside the camera transform. Its cutout was positioned from anchors in canvas coordinates but rendered untransformed, which was already slightly wrong under a zoom and would have been badly wrong across a canvas.

Inside the transform it also stays in sync while the camera animates, for free. Transforming the cutout from outside could not: the camera's rendered position lives in the effect's interpolated `animatableData`, not in a value another view can read, so the cutout would snap while the camera sprang. The dim covers the canvas, so the area beyond a canvas edge is left to the deck's background.

## Test plan

- `./scripts/test.sh` — 74 tests pass, 8 of them new: the three extents, the canvas defaults and axis independence, the `Slide` default and a declared canvas, and the regression above
- `make lint` clean
- `AboutCanvas` added to the example deck: three viewport-wide panels, two pans across them, a zoom into an element too small to read from the first panel, and home again
- `.content` is not used by the example deck, so it was checked separately by rendering a tall slide's every step and reading the images back: the cards keep their own height rather than compressing into the viewport, and the camera reaches the last one

`make proj` was re-run for the new file, which also gave the example project a scheme — it now builds from the command line, where it previously needed Xcode.

## Next

PR3: manual pan and pinch as an override on top of the action-derived camera, opted into per slide, with a return control at the bottom-trailing corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)