### PR TITLE
Let the presenter move the camera

### DIFF
--- a/Examples/SwiftDexExample/Slides/CustomAnimation/AboutCanvas.swift
+++ b/Examples/SwiftDexExample/Slides/CustomAnimation/AboutCanvas.swift
@@ -17,6 +17,7 @@ struct AboutCanvas: Slide {
                     color: .cyan
                 ) {
                     "Give a slide a **`canvas`** and it keeps laying out past the edge of the viewport."
+                    "Scroll or pinch to travel yourself — the control in the corner returns the camera to the script."
                 }
             }
             Element(.element(1)) {

--- a/Sources/SwiftDex/Core/Deck/DeckController.swift
+++ b/Sources/SwiftDex/Core/Deck/DeckController.swift
@@ -103,6 +103,7 @@ public final class DeckController {
 
         if state.currentClick > 0 {
             slideValueStore.clear()
+            state.cameraOverride = nil
             state.position = .click(state.currentClick - 1)
         }
         else if slideNumber > 0 {

--- a/Sources/SwiftDex/Core/Slide/CameraControl.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraControl.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Who is allowed to move a slide's camera.
+///
+/// A slide that declares a `canvas` is interactive by default, because a slide
+/// with somewhere to go that cannot be moved is a surprise. Write the value
+/// explicitly to take that back: a canvas whose tour is scripted, and must stay
+/// on script, is `.scripted`.
+public enum CameraControl: Equatable {
+    /// The camera goes only where the slide's `Camera` actions put it.
+    case scripted
+
+    /// The presenter can also move the camera, with the trackpad.
+    ///
+    /// Manual movement is a temporary layer over the actions: the next `Camera`
+    /// action discards it, as does the control that appears while it is in
+    /// effect.
+    case interactive
+}

--- a/Sources/SwiftDex/Core/Slide/CameraView/CameraFrame.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraView/CameraFrame.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Everything needed to turn a trackpad event into a camera movement.
+///
+/// Trackpad events arrive in the window's coordinates, while the camera is
+/// addressed in the canvas's. The conversion needs the surface's on-screen
+/// scale and where the camera is pointing, both of which change as the
+/// presentation runs, so the current values are handed to the event handler
+/// through `LiveCameraFrame` rather than captured when the monitor is
+/// installed.
+struct CameraFrame: Equatable {
+    /// The size of the surface the camera maps onto, in slide units.
+    var viewport: CGSize = .zero
+
+    /// Where the actions alone put the camera.
+    ///
+    /// The presenter's movement is layered onto this, so it is the base every
+    /// override is relative to.
+    var actionRect: CGRect = .zero
+
+    /// The camera rectangle actually on screen, including any movement.
+    var currentRect: CGRect = .zero
+
+    /// Window points per slide unit.
+    var onScreenScale: CGFloat = 1
+
+    /// The surface's top-left corner in the window's coordinates.
+    var origin: CGPoint = .zero
+}
+
+extension CameraFrame {
+    /// Slide units per canvas unit at the current camera rectangle.
+    var magnification: CGFloat {
+        guard currentRect.width > 0, currentRect.height > 0 else {
+            return 1
+        }
+        return min(viewport.width / currentRect.width, viewport.height / currentRect.height)
+    }
+
+    /// Canvas units per window point.
+    var canvasPerPoint: CGFloat {
+        let scale = onScreenScale * magnification
+        return scale > 0 ? 1 / scale : 0
+    }
+
+    /// The canvas point under a location in the window's coordinates, or `nil`
+    /// when that location is not over this surface.
+    ///
+    /// A monitor sees every event the window gets, so this doubles as the test
+    /// for whether an event was meant for the slide at all.
+    func canvasPoint(atWindowLocation location: CGPoint) -> CGPoint? {
+        guard onScreenScale > 0 else {
+            return nil
+        }
+        let local = CGPoint(
+            x: (location.x - origin.x) / onScreenScale,
+            y: (location.y - origin.y) / onScreenScale
+        )
+        guard local.x >= 0, local.x <= viewport.width,
+            local.y >= 0, local.y <= viewport.height
+        else {
+            return nil
+        }
+        let magnification = magnification
+        return CGPoint(
+            x: currentRect.midX + (local.x - viewport.width / 2) / magnification,
+            y: currentRect.midY + (local.y - viewport.height / 2) / magnification
+        )
+    }
+}
+
+/// A reference to the latest `CameraFrame`.
+///
+/// The event monitor is installed once, so its handler cannot close over a
+/// value that changes every click. It closes over this instead.
+final class LiveCameraFrame {
+    var value = CameraFrame()
+}

--- a/Sources/SwiftDex/Core/Slide/CameraView/CameraOverride.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraView/CameraOverride.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// A presenter's movement of the camera, layered over where the actions put it.
+///
+/// The override is a delta rather than a position, so the thing it is layered
+/// over stays a pure function of the timeline and never has to be saved. That
+/// is also what makes returning free: dropping the override *is* the return,
+/// with nothing to restore.
+///
+/// `anchorClick` is the click the movement started on, which is how the
+/// timeline decides the override is stale — see
+/// `SlideState.effectiveCameraOverride`.
+struct CameraOverride: Equatable {
+    /// How much the presenter has magnified the camera. `1` is the action's own
+    /// zoom level.
+    var scale: CGFloat = 1
+
+    /// How far the presenter has moved the camera, in canvas units.
+    var translation: CGSize = .zero
+
+    /// The click the movement started on.
+    let anchorClick: Int
+
+    /// The range the presenter may magnify within.
+    ///
+    /// Unlike travel, which is deliberately unbounded, magnification is clamped:
+    /// a camera rectangle that collapses or inverts has no sensible transform.
+    static let scaleLimits: ClosedRange<CGFloat> = 0.25...8
+
+    var isIdentity: Bool {
+        scale == 1 && translation == .zero
+    }
+
+    /// The camera rectangle this override produces from the one the actions
+    /// resolved to.
+    func apply(to rect: CGRect) -> CGRect {
+        let size = CGSize(width: rect.width / scale, height: rect.height / scale)
+        return CGRect(
+            x: rect.midX - size.width / 2 + translation.width,
+            y: rect.midY - size.height / 2 + translation.height,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    /// Magnifies by `factor`, keeping `pivot` where it is on screen.
+    ///
+    /// Scaling alone holds the camera's centre still, so the pivot is kept by
+    /// moving the centre towards it by the share the magnification took away.
+    mutating func magnify(by factor: CGFloat, about pivot: CGPoint, in rect: CGRect) {
+        let clamped = min(max(scale * factor, Self.scaleLimits.lowerBound), Self.scaleLimits.upperBound)
+        guard clamped != scale else {
+            return
+        }
+        let applied = clamped / scale
+        scale = clamped
+
+        let centre = apply(to: rect)
+        translation.width += (pivot.x - centre.midX) * (1 - 1 / applied)
+        translation.height += (pivot.y - centre.midY) * (1 - 1 / applied)
+    }
+}

--- a/Sources/SwiftDex/Core/Slide/CameraView/CameraReturnControl.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraView/CameraReturnControl.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// The way back to where the actions put the camera.
+///
+/// Shown only while the presenter has moved the camera, which makes its
+/// presence the signal that the slide is off script and its disappearance the
+/// signal that it is back on. That is why it is not hidden from the audience:
+/// it is part of the performance, like the grid overview, rather than chrome.
+///
+/// It belongs outside the camera transform. Inside it, the control would travel
+/// with the canvas and leave the screen exactly when it is needed.
+struct CameraReturnControl: View {
+    @Environment(AnySlideViewModel.self) private var slideViewModel
+    @Environment(\.colorStyle) private var colorStyle
+
+    var body: some View {
+        let isPresented = slideViewModel.cameraOverride != nil
+
+        return ZStack {
+            Button(action: returnToScript) {
+                Image(systemName: "scope")
+                    .font(.system(size: 28, weight: .medium))
+                    .foregroundStyle(colorStyle.backgroundColor)
+                    .frame(width: 72, height: 72)
+                    .background(
+                        Circle().fill(colorStyle.textColor(textStyle: .body).opacity(0.55))
+                    )
+            }
+            .buttonStyle(.plain)
+            .padding(40)
+            // Present the shortcut only alongside the control, so it is not
+            // competing for Escape with anything else on the surface.
+            .background {
+                Button("", action: returnToScript)
+                    .keyboardShortcut(.cancelAction)
+                    .opacity(0)
+            }
+        }
+        .opacity(isPresented ? 1 : 0)
+        .allowsHitTesting(isPresented)
+        .animation(.easeInOut(duration: 0.2), value: isPresented)
+    }
+}
+
+private extension CameraReturnControl {
+    func returnToScript() {
+        // Animated here rather than by the camera itself: dropping the override
+        // does not move the slide's click, which is what the camera's own
+        // animation is keyed on.
+        withAnimation(.spring()) {
+            slideViewModel.clearCameraOverride()
+        }
+    }
+}

--- a/Sources/SwiftDex/Core/Slide/CameraView/CameraView.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraView/CameraView.swift
@@ -6,8 +6,13 @@ struct CameraView<Content: View, Background: View>: View {
     @Environment(\.slideSize) private var slideSize
 
     let canvas: SlideCanvas
+    let cameraControl: CameraControl
     @ViewBuilder let content: () -> Content
     @ViewBuilder let background: () -> Background
+
+    // The event monitor is installed once, so its handler reads the geometry
+    // from here instead of closing over values that change every click.
+    @State private var live = LiveCameraFrame()
 
     var body: some View {
         GeometryReader { proxy in
@@ -17,19 +22,34 @@ struct CameraView<Content: View, Background: View>: View {
             // rectangle comes from the whole history, because `pan` is
             // relative to the operation before it.
             ActionReader(Camera.self, elementID: .none, clicks: 1) { progress in
+                let action = actionRect(proxy: proxy)
+                let current = slideViewModel.cameraOverride?.apply(to: action) ?? action
+
                 canvasContent
                     .modifier(
                         // `ignoredByLayout` keeps the camera transform out of layout, so
                         // anchors keep resolving in untransformed canvas coordinates and a
                         // later target is not distorted by where the camera is now.
-                        CameraEffect(rect: cameraRect(proxy: proxy), viewport: slideSize)
+                        CameraEffect(rect: current, viewport: slideSize)
                             .ignoredByLayout()
                     )
+                    .onChange(of: frame(proxy: proxy, action: action, current: current), initial: true) {
+                        live.value = $1
+                    }
             } animation: { progress in
                 progress.current != nil ? .spring() : nil
             }
         }
         .clipped()
+        .modifier(
+            TrackpadCameraInput(
+                isEnabled: cameraControl == .interactive,
+                live: live,
+                onPan: pan,
+                onMagnify: magnify,
+                onReturn: returnToScript
+            )
+        )
     }
 }
 
@@ -76,7 +96,41 @@ private extension CameraView {
         CGRect(origin: .zero, size: slideSize)
     }
 
-    func cameraRect(proxy: GeometryProxy) -> CGRect {
+    func frame(proxy: GeometryProxy, action: CGRect, current: CGRect) -> CameraFrame {
+        let global = proxy.frame(in: .global)
+        // `.global` carries the scale the surface is displayed at, which is the
+        // factor between a trackpad's window points and the slide's own units.
+        let onScreenScale = proxy.size.width > 0 ? global.width / proxy.size.width : 1
+        return CameraFrame(
+            viewport: slideSize,
+            actionRect: action,
+            currentRect: current,
+            onScreenScale: onScreenScale,
+            origin: global.origin
+        )
+    }
+
+    func pan(by translation: CGSize) {
+        slideViewModel.updateCameraOverride {
+            $0.translation.width += translation.width
+            $0.translation.height += translation.height
+        }
+    }
+
+    func magnify(by factor: CGFloat, about pivot: CGPoint) {
+        let action = live.value.actionRect
+        slideViewModel.updateCameraOverride {
+            $0.magnify(by: factor, about: pivot, in: action)
+        }
+    }
+
+    func returnToScript() {
+        withAnimation(.spring()) {
+            slideViewModel.clearCameraOverride()
+        }
+    }
+
+    func actionRect(proxy: GeometryProxy) -> CGRect {
         CameraRect.resolve(
             history: slideViewModel.actionHistory(for: .none, type: Camera.self),
             home: home

--- a/Sources/SwiftDex/Core/Slide/CameraView/TrackpadCameraInput.swift
+++ b/Sources/SwiftDex/Core/Slide/CameraView/TrackpadCameraInput.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+
+/// Lets the presenter move the camera with the trackpad.
+///
+/// The events are taken with a local event monitor rather than SwiftUI
+/// gestures, so that moving the camera never enters gesture arbitration with
+/// the tap that advances the slide. It also means momentum arrives for free:
+/// AppKit keeps delivering scroll events after the fingers lift.
+///
+/// The monitor is installed only while an interactive slide is on screen, so a
+/// deck of ordinary slides never intercepts anything.
+struct TrackpadCameraInput: ViewModifier {
+    let isEnabled: Bool
+    let live: LiveCameraFrame
+
+    /// A travel, in canvas units.
+    let onPan: (CGSize) -> Void
+
+    /// A magnification, and the canvas point to keep still while it happens.
+    let onMagnify: (CGFloat, CGPoint) -> Void
+
+    /// A request to give the camera back to the actions.
+    let onReturn: () -> Void
+
+    @State private var monitor: Any?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { install() }
+            .onDisappear { remove() }
+            .onChange(of: isEnabled) { _, enabled in
+                enabled ? install() : remove()
+            }
+    }
+}
+
+private extension TrackpadCameraInput {
+    func install() {
+        guard isEnabled, monitor == nil else {
+            return
+        }
+        monitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.scrollWheel, .magnify, .smartMagnify]
+        ) { event in
+            handle(event) ? nil : event
+        }
+    }
+
+    func remove() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        monitor = nil
+    }
+
+    /// Returns whether the event was consumed.
+    func handle(_ event: NSEvent) -> Bool {
+        let frame = live.value
+
+        // The monitor sees the whole application's events. Resolving the
+        // location against this surface is both the conversion and the test for
+        // whether the event was meant for it.
+        guard let window = event.window,
+            let pivot = frame.canvasPoint(atWindowLocation: flipped(event.locationInWindow, in: window))
+        else {
+            return false
+        }
+
+        switch event.type {
+        case .scrollWheel:
+            let scale = frame.canvasPerPoint
+            // A scroll asks for the content to move; the camera moves the other
+            // way, by the distance in canvas units that covers on screen.
+            onPan(
+                CGSize(
+                    width: -event.scrollingDeltaX * scale,
+                    height: -event.scrollingDeltaY * scale
+                )
+            )
+
+        case .magnify:
+            onMagnify(1 + event.magnification, pivot)
+
+        case .smartMagnify:
+            onReturn()
+
+        default:
+            return false
+        }
+        return true
+    }
+
+    /// AppKit reports a location from the window's bottom-left corner; the
+    /// surface is measured from its top-left one.
+    func flipped(_ location: CGPoint, in window: NSWindow) -> CGPoint {
+        let height = window.contentView?.bounds.height ?? window.frame.height
+        return CGPoint(x: location.x, y: height - location.y)
+    }
+}

--- a/Sources/SwiftDex/Core/Slide/Slide.swift
+++ b/Sources/SwiftDex/Core/Slide/Slide.swift
@@ -22,6 +22,12 @@ public protocol Slide: Flow {
     /// canvas gives the slide room the viewport cannot show at once, reached
     /// with `Camera`.
     var canvas: SlideCanvas { get }
+
+    /// Who is allowed to move this slide's camera.
+    ///
+    /// Derived from `canvas` by default: a slide with somewhere to go can be
+    /// moved. Write it to override that in either direction.
+    var cameraControl: CameraControl { get }
 }
 
 public extension Slide {
@@ -38,6 +44,16 @@ public extension Slide {
     /// Default value for `canvas`.
     var canvas: SlideCanvas {
         .slide
+    }
+
+    /// Default value for `cameraControl`.
+    ///
+    /// A slide that declared a canvas has somewhere to go, and a presenter who
+    /// tries to travel there should not first have to discover a flag. A slide
+    /// that did not declare one is untouched, so nothing a deck already
+    /// contains gains behaviour it never asked for.
+    var cameraControl: CameraControl {
+        canvas == .slide ? .scripted : .interactive
     }
 
     /// Default implemenation for `flatten()`.

--- a/Sources/SwiftDex/Core/Slide/SlideState.swift
+++ b/Sources/SwiftDex/Core/Slide/SlideState.swift
@@ -37,6 +37,12 @@ struct SlideState {
     var clickCounts: [ClickCountKey: Int] = [:]
     var latestUserOperation: UserOperation?
 
+    /// The presenter's own movement of the camera, if any.
+    ///
+    /// Held raw: whether it still applies is decided by the timeline, in
+    /// `effectiveCameraOverride`.
+    var cameraOverride: CameraOverride?
+
     init(
         actionContainer: ActionContainer = .empty,
         position: SlidePosition = .click(0)
@@ -57,6 +63,7 @@ extension SlideState: Equatable {
         lhs.position == rhs.position
             && lhs.clickCounts == rhs.clickCounts
             && lhs.latestUserOperation == rhs.latestUserOperation
+            && lhs.cameraOverride == rhs.cameraOverride
     }
 }
 
@@ -220,6 +227,41 @@ extension SlideState {
             // distinct structural positions cannot currently share a click.
             .sorted { ($0.1, $0.2) < ($1.1, $1.2) }
             .map { $0.0 }
+    }
+
+    /// The click the most recently started occurrence of `A` began on, or `0`
+    /// when none has started.
+    func latestActionStart<A: Action>(
+        for elementID: ElementID,
+        type: A.Type
+    ) -> Int {
+        guard let chain: [TaggedAction<A>] = actionContainer.chains[elementID]?[A.self] else {
+            return 0
+        }
+
+        let click = currentClick
+        let intervals = intervals()
+        return
+            chain
+            .compactMap { intervals[$0.id]?.start }
+            .filter { $0 <= click }
+            .max() ?? 0
+    }
+
+    /// The presenter's camera movement, if the timeline has not overruled it.
+    ///
+    /// A `Camera` action that started after the movement did is the slide
+    /// taking the camera back, so the movement is dropped. Deciding this by
+    /// comparing clicks rather than by reacting to the action keeps it a pure
+    /// function: a mirrored surface reaches the same answer without being told,
+    /// and the composite rectangle animates from wherever the presenter left it
+    /// to wherever the action points, because only one value changed.
+    var effectiveCameraOverride: CameraOverride? {
+        guard let override = cameraOverride else {
+            return nil
+        }
+        return latestActionStart(for: .none, type: Camera.self) > override.anchorClick
+            ? nil : override
     }
 
     private func duration(of node: TimelineNode) -> Int {

--- a/Sources/SwiftDex/Core/Slide/SlideView.swift
+++ b/Sources/SwiftDex/Core/Slide/SlideView.swift
@@ -36,11 +36,14 @@ struct SlideView<T>: View where T: Slide {
     }
 
     var body: some View {
-        CameraView(canvas: slide.canvas) {
-            slide.content
-        } background: {
-            slide.background
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ZStack(alignment: .bottomTrailing) {
+            CameraView(canvas: slide.canvas, cameraControl: slide.cameraControl) {
+                slide.content
+            } background: {
+                slide.background
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            CameraReturnControl()
         }
         .environment(viewModel)
         .environmentObject(elementAnchors)

--- a/Sources/SwiftDex/Core/Slide/SlideViewModel/DynamicSlideViewModel.swift
+++ b/Sources/SwiftDex/Core/Slide/SlideViewModel/DynamicSlideViewModel.swift
@@ -37,4 +37,24 @@ final class DynamicSlideViewModel: SlideViewModel {
     ) -> [A] {
         state.actionHistory(for: elementID, type: type)
     }
+
+    var cameraOverride: CameraOverride? {
+        state.effectiveCameraOverride
+    }
+
+    func updateCameraOverride(_ edit: (inout CameraOverride) -> Void) {
+        // A stale override is gone as far as the camera is concerned, so a new
+        // movement starts from the action's own rectangle rather than resuming
+        // one the slide already took back.
+        var override = state.effectiveCameraOverride ?? CameraOverride(anchorClick: state.currentClick)
+        edit(&override)
+        state.cameraOverride = override.isIdentity ? nil : override
+    }
+
+    func clearCameraOverride() {
+        guard state.cameraOverride != nil else {
+            return
+        }
+        state.cameraOverride = nil
+    }
 }

--- a/Sources/SwiftDex/Core/Slide/SlideViewModel/SlideViewModel.swift
+++ b/Sources/SwiftDex/Core/Slide/SlideViewModel/SlideViewModel.swift
@@ -25,6 +25,18 @@ protocol SlideViewModel {
         for elementID: ElementID,
         type: A.Type
     ) -> [A]
+
+    /// The presenter's camera movement in force, or `nil` when the camera is
+    /// where the actions put it.
+    var cameraOverride: CameraOverride? { get }
+
+    /// Edits the presenter's camera movement, starting one anchored at the
+    /// current click if there is none.
+    func updateCameraOverride(_ edit: (inout CameraOverride) -> Void)
+
+    /// Drops the presenter's camera movement, returning the camera to the
+    /// actions.
+    func clearCameraOverride()
 }
 
 @Observable class AnySlideViewModel: SlideViewModel {
@@ -58,5 +70,17 @@ protocol SlideViewModel {
         type: A.Type
     ) -> [A] {
         wrappedViewModel.actionHistory(for: elementID, type: type)
+    }
+
+    var cameraOverride: CameraOverride? {
+        wrappedViewModel.cameraOverride
+    }
+
+    func updateCameraOverride(_ edit: (inout CameraOverride) -> Void) {
+        wrappedViewModel.updateCameraOverride(edit)
+    }
+
+    func clearCameraOverride() {
+        wrappedViewModel.clearCameraOverride()
     }
 }

--- a/Sources/SwiftDex/Core/Slide/SlideViewModel/StaticSlideViewModel.swift
+++ b/Sources/SwiftDex/Core/Slide/SlideViewModel/StaticSlideViewModel.swift
@@ -45,4 +45,12 @@ final class StaticSlideViewModel: SlideViewModel {
     ) -> [A] {
         state.actionHistory(for: elementID, type: type)
     }
+
+    // A preview or a thumbnail has no presenter, so it is always exactly where
+    // the actions put the camera.
+    var cameraOverride: CameraOverride? { nil }
+
+    func updateCameraOverride(_ edit: (inout CameraOverride) -> Void) {}
+
+    func clearCameraOverride() {}
 }

--- a/Tests/SwiftDexTests/Core/CameraOverrideTests.swift
+++ b/Tests/SwiftDexTests/Core/CameraOverrideTests.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+import XCTest
+
+@testable import SwiftDex
+
+/// Tests for the presenter's own camera movement, and for the rule that decides
+/// when the slide takes the camera back.
+final class CameraOverrideTests: XCTestCase {
+    private let viewport = CGSize(width: 1920, height: 1080)
+    private let action = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+
+    /// Where a canvas point lands on screen, for a given camera rectangle.
+    private func onScreen(_ point: CGPoint, camera: CGRect) -> CGPoint {
+        let scale = min(viewport.width / camera.width, viewport.height / camera.height)
+        return CGPoint(
+            x: viewport.width / 2 + (point.x - camera.midX) * scale,
+            y: viewport.height / 2 + (point.y - camera.midY) * scale
+        )
+    }
+
+    // MARK: - Applying a movement
+
+    func test_identity_leavesTheActionsRectangleAlone() {
+        XCTAssertEqual(CameraOverride(anchorClick: 0).apply(to: action), action)
+        XCTAssertTrue(CameraOverride(anchorClick: 0).isIdentity)
+    }
+
+    func test_translation_movesWithoutResizing() {
+        var override = CameraOverride(anchorClick: 0)
+        override.translation = CGSize(width: 600, height: -200)
+
+        let moved = override.apply(to: action)
+        XCTAssertEqual(moved, CGRect(x: 600, y: -200, width: 1920, height: 1080))
+    }
+
+    func test_scale_shrinksTheRectangleAboutItsCentre() {
+        var override = CameraOverride(anchorClick: 0)
+        override.scale = 2
+
+        let zoomed = override.apply(to: action)
+        XCTAssertEqual(zoomed, CGRect(x: 480, y: 270, width: 960, height: 540))
+        XCTAssertEqual(zoomed.midX, action.midX, "magnifying must not move the camera")
+        XCTAssertEqual(zoomed.midY, action.midY)
+    }
+
+    // MARK: - Magnifying about a pivot
+
+    func test_magnify_keepsThePivotWhereItIsOnScreen() {
+        let pivot = CGPoint(x: 1500, y: 300)
+        var override = CameraOverride(anchorClick: 0)
+        let before = onScreen(pivot, camera: override.apply(to: action))
+
+        override.magnify(by: 1.5, about: pivot, in: action)
+        let after = onScreen(pivot, camera: override.apply(to: action))
+
+        XCTAssertEqual(after.x, before.x, accuracy: 0.001)
+        XCTAssertEqual(after.y, before.y, accuracy: 0.001)
+        XCTAssertEqual(override.scale, 1.5, accuracy: 0.001)
+    }
+
+    func test_magnify_keepsThePivotAcrossSuccessiveEvents() {
+        // A pinch arrives as a stream of small magnifications; each one has to
+        // hold the pivot, not just the first.
+        let pivot = CGPoint(x: 400, y: 800)
+        var override = CameraOverride(anchorClick: 0)
+        let before = onScreen(pivot, camera: override.apply(to: action))
+
+        for _ in 0..<20 {
+            override.magnify(by: 1.05, about: pivot, in: action)
+        }
+
+        let after = onScreen(pivot, camera: override.apply(to: action))
+        XCTAssertEqual(after.x, before.x, accuracy: 0.001)
+        XCTAssertEqual(after.y, before.y, accuracy: 0.001)
+        XCTAssertGreaterThan(override.scale, 2)
+    }
+
+    func test_magnify_isClampedAtBothEnds() {
+        var override = CameraOverride(anchorClick: 0)
+        for _ in 0..<200 {
+            override.magnify(by: 1.5, about: CGPoint(x: 960, y: 540), in: action)
+        }
+        XCTAssertEqual(override.scale, CameraOverride.scaleLimits.upperBound)
+
+        for _ in 0..<400 {
+            override.magnify(by: 0.5, about: CGPoint(x: 960, y: 540), in: action)
+        }
+        XCTAssertEqual(override.scale, CameraOverride.scaleLimits.lowerBound)
+    }
+
+    // MARK: - When the slide takes the camera back
+
+    private func createState() -> SlideState {
+        @ActionContainerBuilder func build() -> ActionContainer {
+            Camera(.pan(to: .element(0)))
+            FakeAction(elementID: .element(1))
+            Camera(.reset)
+        }
+        return SlideState(actionContainer: build())
+    }
+
+    func test_latestActionStart_isTheMostRecentlyStartedOccurrence() {
+        var state = createState()
+        XCTAssertEqual(state.latestActionStart(for: .none, type: Camera.self), 0)
+
+        state.position = .click(1)
+        XCTAssertEqual(state.latestActionStart(for: .none, type: Camera.self), 1)
+
+        state.position = .click(2)
+        XCTAssertEqual(state.latestActionStart(for: .none, type: Camera.self), 1, "click 2 is not a Camera action")
+
+        state.position = .click(3)
+        XCTAssertEqual(state.latestActionStart(for: .none, type: Camera.self), 3)
+    }
+
+    func test_override_survivesAClickThatIsNotACameraAction() {
+        var state = createState()
+        state.position = .click(1)
+        state.cameraOverride = CameraOverride(scale: 2, translation: .zero, anchorClick: 1)
+
+        state.position = .click(2)
+        XCTAssertNotNil(state.effectiveCameraOverride, "an action elsewhere on the slide leaves the camera alone")
+    }
+
+    func test_override_isDroppedByALaterCameraAction() {
+        var state = createState()
+        state.position = .click(1)
+        state.cameraOverride = CameraOverride(scale: 2, translation: .zero, anchorClick: 1)
+
+        state.position = .click(3)
+        XCTAssertNil(state.effectiveCameraOverride, "the slide put the camera somewhere, so the movement is stale")
+    }
+
+    func test_override_isNotDroppedByTheCameraActionItWasMadeOn() {
+        var state = createState()
+        state.position = .click(1)
+        state.cameraOverride = CameraOverride(scale: 2, translation: .zero, anchorClick: 1)
+
+        XCTAssertNotNil(
+            state.effectiveCameraOverride,
+            "moving the camera after an action ran must not immediately undo itself"
+        )
+    }
+}

--- a/Tests/SwiftDexTests/Core/DeckControllerTests.swift
+++ b/Tests/SwiftDexTests/Core/DeckControllerTests.swift
@@ -19,6 +19,27 @@ final class DeckControllerTests: XCTestCase {
         XCTAssertEqual(controller.slideNumber, 1)
     }
 
+    func test_backward_clearsTheCameraOverride() {
+        let controller = DeckController(deck: MyDeck())
+        controller.forward()
+        controller.state.cameraOverride = CameraOverride(anchorClick: controller.currentClick)
+
+        controller.backward()
+
+        // Rewinding is deterministic, as it is for `@SlideValue`: stepping back
+        // to a click must not depend on what the presenter did the first time.
+        XCTAssertNil(controller.state.cameraOverride)
+    }
+
+    func test_movingToAnotherSlide_clearsTheCameraOverride() {
+        let controller = DeckController(deck: MyDeck())
+        controller.state.cameraOverride = CameraOverride(anchorClick: 0)
+
+        controller.randomAccess(slideNumber: 1)
+
+        XCTAssertNil(controller.state.cameraOverride)
+    }
+
     func test_forward() {
         let controller = DeckController(deck: MyDeck())
 

--- a/Tests/SwiftDexTests/Core/SlideCanvasTests.swift
+++ b/Tests/SwiftDexTests/Core/SlideCanvasTests.swift
@@ -62,6 +62,30 @@ final class SlideCanvasTests: XCTestCase {
         XCTAssertEqual(PlainSlide().canvas, .slide)
     }
 
+    func test_cameraControl_followsWhetherThereIsSomewhereToGo() {
+        // A slide with a canvas can be moved without the author having to
+        // discover a second flag; one without a canvas gains nothing.
+        XCTAssertEqual(PlainSlide().cameraControl, .scripted)
+        XCTAssertEqual(WideSlide().cameraControl, .interactive)
+        XCTAssertEqual(TallSlide().cameraControl, .interactive)
+    }
+
+    func test_cameraControl_canBeOverriddenInEitherDirection() {
+        XCTAssertEqual(ScriptedTourSlide().cameraControl, .scripted)
+        XCTAssertEqual(InteractivePlainSlide().cameraControl, .interactive)
+    }
+
+    private struct ScriptedTourSlide: Slide {
+        var canvas: SlideCanvas { .init(width: .points(5760)) }
+        var cameraControl: CameraControl { .scripted }
+        var content: some View { EmptyView() }
+    }
+
+    private struct InteractivePlainSlide: Slide {
+        var cameraControl: CameraControl { .interactive }
+        var content: some View { EmptyView() }
+    }
+
     func test_slide_declaredCanvasIsKept() {
         XCTAssertEqual(WideSlide().canvas, SlideCanvas(width: .points(5760), height: .slide))
         XCTAssertEqual(TallSlide().canvas, SlideCanvas(width: .slide, height: .content))


### PR DESCRIPTION
Last of three PRs toward slides larger than the screen. #37 gave the viewport a camera, #38 gave it somewhere to go, and this lets the presenter drive it.

## What

```swift
struct SystemMap: Slide {
    var canvas: SlideCanvas { .init(width: .points(5760)) }
    // .interactive already — see below
}

struct ScriptedTour: Slide {
    var canvas: SlideCanvas { .init(width: .points(5760)) }
    var cameraControl: CameraControl { .scripted }   // hands off
}
```

Two-finger scroll travels, pinch magnifies about the cursor, and a control at the bottom-trailing corner returns the camera to where the actions put it. Escape and a two-finger double tap do the same.

## The default is derived, not flat

`cameraControl` defaults to `canvas == .slide ? .scripted : .interactive`. A slide that declared a canvas has somewhere to go, and a presenter who tries to travel there should not first have to discover a flag; a slide that did not declare one is untouched, so nothing an existing deck contains gains behaviour it never asked for. Deriving rather than forcing keeps the property overridable in both directions — a canvas whose tour must stay on script writes `.scripted`, and an ordinary slide that wants to be zoomed into during Q&A writes `.interactive`.

## The override is a delta, not a position

This is what makes the whole feature cheap. Where the actions put the camera is a pure function of the timeline that was never stored anywhere, so returning needs no snapshot and no history — **dropping the override *is* the return**. One value then drives everything: whether the camera is off script, where it is, and whether the control is shown.

Staleness is decided by the timeline, not by reacting to events: an override is dropped when a `Camera` action started after the click the movement was made on. Comparing clicks keeps it a pure function, so a mirrored surface reaches the same answer without being told, and the composite rectangle animates straight from wherever the presenter left it to the action's, because only one value changed. Rewinds clear it outright, matching how `@SlideValue` keeps stepping back deterministic.

## Input

A local `NSEvent` monitor rather than SwiftUI gestures, so travelling never enters gesture arbitration with the tap that advances the slide — and momentum arrives for free, since AppKit keeps delivering scroll events after the fingers lift. The monitor is installed only while an interactive slide is on screen.

Trackpad events arrive in window coordinates while the camera is addressed in canvas coordinates. The factor between them is read off `proxy.frame(in: .global)`, which carries the scale the surface is displayed at — checked against `ScaleEffectView`'s own computation before relying on it. Resolving a location against the surface doubles as the test for whether an event was meant for the slide at all.

Travel is unbounded, as agreed — beyond a canvas edge is the deck's background. Magnification is not: a camera rectangle that collapses or inverts has no sensible transform, so it is clamped to 0.25×–8×.

## The return control is for the audience too

It is not hidden. Its presence says the slide is off script and its disappearance says it is back — worth seeing, in the same way the grid overview is a performance state rather than chrome. So it is styled from `ColorStyle`, and it lives outside the camera transform: inside it, the control would travel with the canvas and leave the screen exactly when it is needed.

## Dropped from the design

The plan had a second gate — pan only when the camera rectangle is smaller than the canvas. That was designed when pinch was going to be always-on; with per-slide opt-in the permission gate alone prevents stray movement, and keeping the capability gate would have reintroduced the canvas measurement #38 established is unnecessary. One gate, not two.

## Test plan

- `./scripts/test.sh` — 88 tests pass, 14 of them new: applying a movement, the pivot holding still across a single magnification and across twenty successive ones, clamping at both ends, `latestActionStart`, an override surviving a non-camera click, being dropped by a later `Camera` action, not being dropped by the action it was made on, and the controller clearing it on rewind and on changing slide
- `make lint` clean
- rendering verified by writing slides with an override already in effect out to images and reading them back: the camera reflects a pan and a pinch, and the control appears only with an override and stays put in the viewport while the canvas travels beneath it
- trackpad gestures tried by hand in the example deck on `AboutCanvas` — scroll direction and tracking speed, pinch about the cursor, the control, Escape, two-finger double tap, and advancing while off script

🤖 Generated with [Claude Code](https://claude.com/claude-code)